### PR TITLE
Require -d and -r to name existing recursive types

### DIFF
--- a/src/Transform/DR.hs
+++ b/src/Transform/DR.hs
@@ -339,7 +339,7 @@ derefunThese ps recs = foldl (\ ps (rtp, dr) -> ps >>= derefunThis' dr rtp) (ret
 
 insertProgs' :: Var -> Prog -> Prog -> [Prog] -> [Prog]
 insertProgs' rtp dat fun [] = []
-insertProgs' rtp dat fun (ProgData y cs : ds) = if y == rtp then ProgData y cs : dat : fun : ds else ProgData y cs : insertProgs' rtp dat fun ds
+insertProgs' rtp dat fun (ProgData y cs : ds) | y == rtp = ProgData y cs : dat : fun : ds
 insertProgs' rtp dat fun (d : ds) = d : insertProgs' rtp dat fun ds
 
 -- Inserts new Fold/Unfold progs right after the datatype they correspond to


### PR DESCRIPTION
Now `compiler.exe -r Flips` doesn't silently defunctionalize `Flips_inst0`. Instead it says `No recursive datatype named Flips (did you mean Flips_inst0?)`