### PR TITLE
Monomorphize externs

### DIFF
--- a/src/Transform/Monomorphize.hs
+++ b/src/Transform/Monomorphize.hs
@@ -216,4 +216,4 @@ monomorphizeFile (SProgs sps stm) =
       xis'' = fmap (\ tiss -> Map.fromList (zip (Set.toList tiss) [0..])) (semimap xis')
       xis''' = overrideCtorInsts xis'' sps
   in
-     Progs (concat (makeInstantiations xis''' <$> sps)) (renameCalls xis''' stm)
+    Progs (concat (makeInstantiations xis''' <$> sps)) (renameCalls xis''' stm)

--- a/tests/good/type_parameter_unused.ppl
+++ b/tests/good/type_parameter_unused.ppl
@@ -4,4 +4,3 @@ define copy_mono = \x: MyBool Nat. (x, x);
 define copy_poly = \x. (x, x);
 extern e: MyBool Nat;
 (copy_mono MyFalse, copy_poly MyFalse)
-


### PR DESCRIPTION
This is trying to get at the root of the same problem that #86 is trying to fix, which is that externs aren't monomorphized, so they still have type parameters during stages that assume there are no type parameters.
