### PR TITLE
Separate tag and type params

### DIFF
--- a/src/Compile/Compile.hs
+++ b/src/Compile/Compile.hs
@@ -80,7 +80,7 @@ mkRuleReps reps lhs ns es xs =
 ctorRules :: Ctxt -> Ctor -> Type -> [Ctor] -> RuleM
 ctorRules g (Ctor x as) y cs =
   let as' = [(etaName x i, a) | (i, a) <- enumerate as]
-      tm = TmVarG CtorVar x [] [(TmVarL a atp, atp) | (a, atp) <- as'] y
+      tm = TmVarG CtorVar x [] [] [(TmVarL a atp, atp) | (a, atp) <- as'] y
       fac = ctorFactorNameDefault x as y in
     addFactor fac (getCtorWeightsFlat (domainValues g) (Ctor x as) cs) +>
     foldr (\ tp r -> type2fgg g tp +> r) returnRule as +>
@@ -97,7 +97,7 @@ caseRule g all_fvs xs_ctm ctm y cs tp (Case x as xtm) =
       vctp : vtp : unused_nps = newNames (TpData y [] [] : tp : snds unused_ps)
       fac = ctorFactorName x (paramsToArgs (nameParams x (snds as))) (TpData y [] [])
   in
-    mkRule (TmCase ctm (y, []) cs tp)
+    mkRule (TmCase ctm (y, [], []) cs tp)
       (vctp : vtp : xs_xtm_as ++ as ++ xs_ctm ++ all_xs ++ unused_ps ++ unused_nps)
       (Edge' (xs_ctm ++ [vctp]) (show ctm) :
        Edge' (xs_xtm_as ++ [vtp]) (show xtm) :
@@ -156,18 +156,18 @@ term2fgg g (TmVarL x tp) =
   type2fgg g tp +>
   addExt x tp
 
-term2fgg g (TmVarG gv x [] [] tp) =
+term2fgg g (TmVarG gv x [] [] [] tp) =
   returnRule -- If this is a ctor/def with no args, we already add its rule when it gets defined
 
-term2fgg g (TmVarG gv x [] as y) =
+term2fgg g (TmVarG gv x [] [] as y) =
   [term2fgg g a | (a, atp) <- as] +>=* \ xss ->
   let (vy : ps) = newNames (y : snds as) in
-    mkRule (TmVarG gv x [] as y) (vy : ps ++ concat xss)
+    mkRule (TmVarG gv x [] [] as y) (vy : ps ++ concat xss)
       (Edge' (ps ++ [vy]) (if gv == CtorVar then ctorFactorNameDefault x (snds as) y else x) :
         [Edge' (xs ++ [vtp]) (show atm) | (xs, (atm, atp), vtp) <- zip3 xss as ps])
       (concat xss ++ [vy])
 
-term2fgg _ (TmVarG _ _ (_:_) _ _) = error "Cannot compile polymorphic code"
+term2fgg _ (TmVarG _ _ _ _ _ _) = error "Cannot compile polymorphic code"
 
 term2fgg g (TmLam x tp tm tp') =
   bindExt True x tp
@@ -192,12 +192,12 @@ term2fgg g (TmApp tm1 tm2 tp2 tp) =
        Edge' [vtp2, vtp, varr] fac]
       (xs1 ++ xs2 ++ [vtp])    
 
-term2fgg g (TmCase tm (y, []) cs tp) =
+term2fgg g (TmCase tm (y, [], []) cs tp) =
   term2fgg g tm +>= \ xs ->
   let fvs = freeVars cs in
     bindCases (Map.toList (Map.union (freeVars tm) fvs)) (map (caseRule g fvs xs tm y cs tp) cs)
 
-term2fgg _ (TmCase _ (_, _:_) _ _) = error "Cannot compile polymorphic code"
+term2fgg _ (TmCase _ _ _ _) = error "Cannot compile polymorphic code"
 
 -- fail (i.e., amb with no arguments) doesn't generate any rules, but
 -- should still generate the left-hand side nonterminal
@@ -314,7 +314,7 @@ prog2fgg g (ProgFun x ps tm tp) =
       (unused_x, unused_tp) = unzip unused_ps
       vtp : unused_n = newNames (tp : unused_tp)
   in
-    mkRule (TmVarG DefVar x [] [] tp) (vtp : tmxs ++ ps ++ unused_n ++ unused_ps)
+    mkRule (TmVarG DefVar x [] [] [] tp) (vtp : tmxs ++ ps ++ unused_n ++ unused_ps)
       (Edge' (tmxs ++ [vtp]) (show tm) : discardEdges' unused_ps unused_n)
       (ps ++ [vtp])
 prog2fgg g (ProgExtern x ps tp) =

--- a/src/Parse/Parse.hs
+++ b/src/Parse/Parse.hs
@@ -294,7 +294,7 @@ TYPE2 ::=
 -- TypeVar
 parseType2 :: [Var] -> ParseM Type
 parseType2 ps = parsePeek >>= \ t -> case t of
-  TkVar v -> parseEat *> if v `elem` ps then pure (TpVar v) else pure (TpData v) <*> parseTypes ps
+  TkVar v -> parseEat *> if v `elem` ps then pure (TpVar v) else pure (TpData v []) <*> parseTypes ps
   _ -> parseType3 ps
 
 
@@ -322,7 +322,7 @@ parseType3 ps = parsePeek >>= \ t -> case t of
         TkRangle -> pure (TpProd Additive [])
         _ -> pure (TpProd Additive) <*> (parseType1 ps >>= \ tp -> parseDelim (parseType1 ps) TkComma [tp])) <* parseDrop TkRangle
   TkBool -> parseEat *> pure tpBool
-  TkVar v -> parseEat *> pure (if v `elem` ps then TpVar v else TpData v [])
+  TkVar v -> parseEat *> pure (if v `elem` ps then TpVar v else TpData v [] [])
   _ -> parseErr "couldn't parse a type here; perhaps add parentheses?"
 
 -- List of Constructors

--- a/src/Scope/Ctxt.hs
+++ b/src/Scope/Ctxt.hs
@@ -42,7 +42,7 @@ ctxtDefGlobal g x tgs ps tp = Map.insert x (DefTerm (DefGlobal tgs ps tp)) g
 -- Add a constructor to the context
 ctxtDefCtor :: Ctxt -> Ctor -> Var -> [Var] -> [Var] -> Ctxt
 ctxtDefCtor g (Ctor x tps) y tgs ps =
-  let tp = joinArrows tps (TpData y (TpVar <$> (tgs ++ ps))) in
+  let tp = joinArrows tps (TpData y (TpVar <$> tgs) (TpVar <$> ps)) in
   Map.insert x (DefTerm (DefCtor tgs ps tp)) g
 
 -- Add a datatype definition to the context,
@@ -70,11 +70,11 @@ ctxtLookupType g x = Map.lookup x g >>= \ d -> case d of
     DefData [] [] cs -> Just cs
     _ -> error "this shouldn't happen"
 
-ctxtLookupType2 :: Ctxt -> Var -> Maybe ([Var], [Ctor])
+ctxtLookupType2 :: Ctxt -> Var -> Maybe ([Var], [Var], [Ctor])
 ctxtLookupType2 g x = Map.lookup x g >>= \ d -> case d of
   DefTerm _ -> Nothing
   DefType dt -> case dt of
-    DefData tgs ps cs -> Just (tgs++ps, cs)
+    DefData tgs ps cs -> Just (tgs, ps, cs)
   
 -- Is this var bound in this context?
 ctxtBinds :: Ctxt -> Var -> Bool

--- a/src/Scope/Name.hs
+++ b/src/Scope/Name.hs
@@ -29,7 +29,7 @@ internalFactorName tm = "v=" ++ show tm
 
 -- Naming convention for constructor factor
 ctorFactorName :: Var -> [(Term, Type)] -> Type -> String
-ctorFactorName x as tp = internalFactorName (TmVarG CtorVar x [] as tp)
+ctorFactorName x as tp = internalFactorName (TmVarG CtorVar x [] [] as tp)
 
 -- FGG factor name for the default ctor rule
 ctorFactorNameDefault :: Var -> [Type] -> Type -> String

--- a/src/Scope/Subst.hs
+++ b/src/Scope/Subst.hs
@@ -121,7 +121,8 @@ instance Substitutable Type where
     substVar y
       (\ y' -> TpData y' tgs' as')
       (const (TpData y tgs' as'))
-      -- allow y := y' tg1 ...
+      -- Allow y := y' tg1 ....
+      -- This is used in TypeInf.Solve in inferData to add tags to a datatype.
       (\ tp' -> case tp' of TpData y' tgs'' [] -> TpData y' (tgs'' ++ tgs') as'
                             _ -> error ("kind error (" ++ y ++ " := " ++ show tp' ++ ")"))
       (TpData y tgs' as')

--- a/src/Scope/Subst.hs
+++ b/src/Scope/Subst.hs
@@ -148,8 +148,8 @@ instance Substitutable Term where
   substM (TmLet x xtm xtp tm tp) =
     freshen x >>= \ x' ->
     pure (TmLet x') <*> substM xtm <*> substM xtp <*> bind x x' (substM tm) <*> substM tp
-  substM (TmCase tm (y, tgs, tis) cs tp) =
-    pure TmCase <*> substM tm <*> (pure ((,,) y) <*> substM tgs <*> substM tis) <*> substM cs <*> substM tp
+  substM (TmCase tm (y, tgs, as) cs tp) =
+    pure TmCase <*> substM tm <*> (pure ((,,) y) <*> substM tgs <*> substM as) <*> substM cs <*> substM tp
   substM (TmAmb tms tp) =
     pure TmAmb <*> substM tms <*> substM tp
   substM (TmFactor wt tm tp) =

--- a/src/Struct/Exprs.hs
+++ b/src/Struct/Exprs.hs
@@ -96,7 +96,7 @@ data AddMult = Additive | Multiplicative
 
 data Type =
     TpArr Type Type                     -- function tp1 -> tp2
-  | TpData Var [Type] [Type]            -- datatype x tg1 ... ti1 ...
+  | TpData Var [Type] [Type]            -- datatype x tg1 ... a1 ...
   | TpVar Var                           -- type variable
   | TpProd AddMult [Type]               -- product (tp1, ...) or <tp1, ...>
   | NoTp                                -- nothing

--- a/src/Struct/Exprs.hs
+++ b/src/Struct/Exprs.hs
@@ -78,17 +78,17 @@ data GlobalVar = CtorVar | DefVar
 -- With the exception of TmLam, the Type at the end of a constructor
 -- below is the type of that expression as a whole
 data Term =
-    TmVarL Var Type                           -- Local var
-  | TmVarG GlobalVar Var [Type] [Arg] Type    -- Global var app: (x ti1 ...) arg1 ...
-  | TmLam Var Type Term Type                  -- \ x : tp1. tm : tp2
-  | TmApp Term Term Type {- -> -} Type        -- (tm1 : (tp1 -> tp2)) (tm2 : tp1) : tp2
-  | TmLet Var Term Type Term Type             -- let x : tp1 = tm1 in tp2 : tp2
-  | TmCase Term (Var, [Type]) [Case] Type     -- (case tm : y [tis] of case*) : tp
-  | TmAmb [Term] Type                         -- amb tm1 tm2 ... tmn : tp
-  | TmFactor Double Term Type                 -- factor wt in tm : tp
-  | TmProd AddMult [Arg]                      -- (tm1 : tp1, tm2 : tp2, ..., tmn : tpn) / <...>
-  | TmElimProd AddMult Term [Param] Term Type -- let (x:X,y:Y,z:Z)/<...> = tm1 in tm2 : tp
-  | TmEqs [Term]                              -- tm1 == tm2 == ...
+    TmVarL Var Type                               -- Local var
+  | TmVarG GlobalVar Var [Type] [Type] [Arg] Type -- Global var app: (x tg1 ... ti1 ...) arg1 ...
+  | TmLam Var Type Term Type                      -- \ x : tp1. tm : tp2
+  | TmApp Term Term Type {- -> -} Type            -- (tm1 : (tp1 -> tp2)) (tm2 : tp1) : tp2
+  | TmLet Var Term Type Term Type                 -- let x : tp1 = tm1 in tp2 : tp2
+  | TmCase Term (Var, [Type], [Type]) [Case] Type -- (case tm : y tg1 ... ti1 ... of case1 ...) : tp
+  | TmAmb [Term] Type                             -- amb tm1 tm2 ... tmn : tp
+  | TmFactor Double Term Type                     -- factor wt in tm : tp
+  | TmProd AddMult [Arg]                          -- (tm1 : tp1, tm2 : tp2, ..., tmn : tpn) / <...>
+  | TmElimProd AddMult Term [Param] Term Type     -- let (x:X,y:Y,z:Z)/<...> = tm1 in tm2 : tp
+  | TmEqs [Term]                                  -- tm1 == tm2 == ...
   deriving (Eq, Ord)
 
 data AddMult = Additive | Multiplicative
@@ -96,7 +96,7 @@ data AddMult = Additive | Multiplicative
 
 data Type =
     TpArr Type Type                     -- function tp1 -> tp2
-  | TpData Var [Type]                   -- datatype x ti1 ...
+  | TpData Var [Type] [Type]            -- datatype x tg1 ... ti1 ...
   | TpVar Var                           -- type variable
   | TpProd AddMult [Type]               -- product (tp1, ...) or <tp1, ...>
   | NoTp                                -- nothing

--- a/src/Struct/Exprs.hs
+++ b/src/Struct/Exprs.hs
@@ -83,7 +83,7 @@ data Term =
   | TmLam Var Type Term Type                      -- \ x : tp1. tm : tp2
   | TmApp Term Term Type {- -> -} Type            -- (tm1 : (tp1 -> tp2)) (tm2 : tp1) : tp2
   | TmLet Var Term Type Term Type                 -- let x : tp1 = tm1 in tp2 : tp2
-  | TmCase Term (Var, [Type], [Type]) [Case] Type -- (case tm : y tg1 ... ti1 ... of case1 ...) : tp
+  | TmCase Term (Var, [Type], [Type]) [Case] Type -- (case tm : y tg1 ... a1 ... of case1 ...) : tp
   | TmAmb [Term] Type                             -- amb tm1 tm2 ... tmn : tp
   | TmFactor Double Term Type                     -- factor wt in tm : tp
   | TmProd AddMult [Arg]                          -- (tm1 : tp1, tm2 : tp2, ..., tmn : tpn) / <...>

--- a/src/Struct/Helpers.hs
+++ b/src/Struct/Helpers.hs
@@ -6,7 +6,7 @@ import Data.List
 -- Gets the type of an elaborated term in O(1) time
 typeof :: Term -> Type
 typeof (TmVarL x tp) = tp
-typeof (TmVarG gv x tis as tp) = tp
+typeof (TmVarG gv x tgs tis as tp) = tp
 typeof (TmLam x tp tm tp') = TpArr tp tp'
 typeof (TmApp tm1 tm2 tp2 tp) = tp
 typeof (TmLet x xtm xtp tm tp) = tp
@@ -126,15 +126,15 @@ paramsToArgs :: [Param] -> [Arg]
 paramsToArgs = map $ \ (a, atp) -> (TmVarL a atp, atp)
 
 -- Turns a constructor into one with all its args applied
-addArgs :: GlobalVar -> Var -> [Type] -> [Arg] -> [Param] -> Type -> Term
-addArgs gv x tis tas vas y =
-  TmVarG gv x tis (tas ++ [(TmVarL a atp, atp) | (a, atp) <- vas]) y
+addArgs :: GlobalVar -> Var -> [Type] -> [Type] -> [Arg] -> [Param] -> Type -> Term
+addArgs gv x tgs tis tas vas y =
+  TmVarG gv x tgs tis (tas ++ [(TmVarL a atp, atp) | (a, atp) <- vas]) y
 
 -- Eta-expands a constructor with the necessary extra args
-etaExpand :: GlobalVar -> Var -> [Type] -> [Arg] -> [Param] -> Type -> Term
-etaExpand gv x tis tas vas y =
+etaExpand :: GlobalVar -> Var -> [Type] -> [Type] -> [Arg] -> [Param] -> Type -> Term
+etaExpand gv x tgs tis tas vas y =
   foldr (\ (a, atp) tm -> TmLam a atp tm (typeof tm))
-    (addArgs gv x tis tas vas y) vas
+    (addArgs gv x tgs tis tas vas y) vas
 
 toArg :: Term -> Arg
 toArg tm = (tm, typeof tm)
@@ -204,9 +204,9 @@ tpUnit = TpProd Multiplicative []
 tpBoolName = "Bool"
 tmTrueName = "True"
 tmFalseName = "False"
-tpBool = TpData tpBoolName []
-tmTrue = TmVarG CtorVar tmTrueName [] [] tpBool
-tmFalse = TmVarG CtorVar tmFalseName [] [] tpBool
+tpBool = TpData tpBoolName [] []
+tmTrue = TmVarG CtorVar tmTrueName [] [] [] tpBool
+tmFalse = TmVarG CtorVar tmFalseName [] [] [] tpBool
 
 builtins :: [UsProg]
 builtins = [

--- a/src/Struct/Show.hs
+++ b/src/Struct/Show.hs
@@ -8,13 +8,13 @@ import Struct.Helpers
 
 toUsTm :: Term -> UsTm
 toUsTm (TmVarL x _) = UsVar x
-toUsTm (TmVarG gv x tis as tp) =
+toUsTm (TmVarG gv x tgs tis as tp) =
   foldl (\ tm (a, _) -> UsApp tm (toUsTm a)) (UsVar {- x -} (foldl (\ x tp -> x ++ " [" ++ show tp ++ "]") x tis)) as
 toUsTm (TmLam x tp tm _) = UsLam x tp (toUsTm tm)
 toUsTm (TmApp tm1 tm2 _ _) = UsApp (toUsTm tm1) (toUsTm tm2)
 toUsTm (TmLet x xtm xtp tm tp) = UsLet x (toUsTm xtm) (toUsTm tm)
 --toUsTm (TmCase tm "Bool" [Case "True" [] thentm, Case "False" [] elsetm] tp) = UsIf (toUsTm tm) (toUsTm thentm) (toUsTm elsetm)
-toUsTm (TmCase tm ("Bool", []) [Case "False" [] elsetm, Case "True" [] thentm] tp) = UsIf (toUsTm tm) (toUsTm thentm) (toUsTm elsetm)
+toUsTm (TmCase tm ("Bool", [], []) [Case "False" [] elsetm, Case "True" [] thentm] tp) = UsIf (toUsTm tm) (toUsTm thentm) (toUsTm elsetm)
 toUsTm (TmCase tm _ cs _) = UsCase (toUsTm tm) (map toCaseUs cs)
 toUsTm (TmAmb [] tp) = UsFail tp
 toUsTm (TmAmb tms tp) = UsAmb [toUsTm tm | tm <- tms]
@@ -73,8 +73,8 @@ instance Show Term where
 
 instance Show Type where
   showsPrec _ (TpVar y) = showString y
-  showsPrec _ (TpData y []) = showString y
-  showsPrec p (TpData y as) = showParen (p > 10) (delimitWith " " (showString y : map (showsPrec 11) as))
+  showsPrec _ (TpData y [] []) = showString y
+  showsPrec p (TpData y tgs tis) = showParen (p > 10) (delimitWith " " (showString y : map (showsPrec 11) (tgs++tis)))
   showsPrec p (TpArr tp1 tp2) = showParen (p > 0) (showsPrec 1 tp1 . showString " -> " . shows tp2)
   showsPrec _ (TpProd am tps) = let (l, r) = amParens am in showString l . delimitWith ", " (map shows tps) . showString r
   showsPrec _ NoTp = id

--- a/src/Struct/Show.hs
+++ b/src/Struct/Show.hs
@@ -9,7 +9,7 @@ import Struct.Helpers
 toUsTm :: Term -> UsTm
 toUsTm (TmVarL x _) = UsVar x
 toUsTm (TmVarG gv x tgs tis as _tp) =
-  foldl (\ tm (a, _) -> UsApp tm (toUsTm a)) (UsVar {- x -} (x ++ " " ++ show tgs ++ " " ++ show tis)) as
+  foldl (\ tm (a, _) -> UsApp tm (toUsTm a)) (UsVar {- x -} (foldl (\ x tp -> x ++ " [" ++ show tp ++ "]") x (tgs++tis))) as
 toUsTm (TmLam x tp tm _) = UsLam x tp (toUsTm tm)
 toUsTm (TmApp tm1 tm2 _ _) = UsApp (toUsTm tm1) (toUsTm tm2)
 toUsTm (TmLet x xtm xtp tm tp) = UsLet x (toUsTm xtm) (toUsTm tm)

--- a/src/Struct/Show.hs
+++ b/src/Struct/Show.hs
@@ -74,7 +74,7 @@ instance Show Term where
 instance Show Type where
   showsPrec _ (TpVar y) = showString y
   showsPrec _ (TpData y [] []) = showString y
-  showsPrec p (TpData y tgs tis) = showParen (p > 10) (delimitWith " " (showString y : map (showsPrec 11) (tgs++tis)))
+  showsPrec p (TpData y tgs as) = showParen (p > 10) (delimitWith " " (showString y : map (showsPrec 11) (tgs++as)))
   showsPrec p (TpArr tp1 tp2) = showParen (p > 0) (showsPrec 1 tp1 . showString " -> " . shows tp2)
   showsPrec _ (TpProd am tps) = let (l, r) = amParens am in showString l . delimitWith ", " (map shows tps) . showString r
   showsPrec _ NoTp = id

--- a/src/Struct/Show.hs
+++ b/src/Struct/Show.hs
@@ -8,8 +8,8 @@ import Struct.Helpers
 
 toUsTm :: Term -> UsTm
 toUsTm (TmVarL x _) = UsVar x
-toUsTm (TmVarG gv x tgs tis as tp) =
-  foldl (\ tm (a, _) -> UsApp tm (toUsTm a)) (UsVar {- x -} (foldl (\ x tp -> x ++ " [" ++ show tp ++ "]") x tis)) as
+toUsTm (TmVarG gv x tgs tis as _tp) =
+  foldl (\ tm (a, _) -> UsApp tm (toUsTm a)) (UsVar {- x -} (x ++ " " ++ show tgs ++ " " ++ show tis)) as
 toUsTm (TmLam x tp tm _) = UsLam x tp (toUsTm tm)
 toUsTm (TmApp tm1 tm2 _ _) = UsApp (toUsTm tm1) (toUsTm tm2)
 toUsTm (TmLet x xtm xtp tm tp) = UsLet x (toUsTm xtm) (toUsTm tm)

--- a/src/Transform/AffLin.hs
+++ b/src/Transform/AffLin.hs
@@ -85,7 +85,7 @@ discard' x (TpProd Multiplicative tps) rtm =
 discard' x xtp@(TpData y []) rtm =
   ask >>= \ g ->
     -- let () = discard x in rtm
-    return (TmElimProd Multiplicative (TmVarG DefVar (discardName y) [] [(x, xtp)] tpUnit) [] rtm (typeof rtm))
+    return (TmElimProd Multiplicative (TmVarG DefVar (discardName y) [] [] [(x, xtp)] tpUnit) [] rtm (typeof rtm))
 discard' _ tp _ = error ("Trying to discard a " ++ show tp)
 
 -- If x : tp contains an affinely-used function, we sometimes need to discard
@@ -140,7 +140,7 @@ affLin (TmVarL x tp) =
   let ltp = affLinTp tp in
   tell (Map.singleton x ltp) >>
   return (TmVarL x ltp)
-affLin (TmVarG gv x tis as y) =
+affLin (TmVarG gv x [] tis as y) =
   -- x is a global var with args as
   -- or a constructor with type args tis and args as
   -- L(x a1 ...) => x L(a1) ...

--- a/src/Transform/DR.hs
+++ b/src/Transform/DR.hs
@@ -18,7 +18,7 @@ collectUnfolds rtp (TmVarG gv x _ _ as tp) = concatMap (\ (atm, atp) -> collectU
 collectUnfolds rtp (TmLam x tp tm tp') = collectUnfolds rtp tm
 collectUnfolds rtp (TmApp tm1 tm2 tp2 tp) = collectUnfolds rtp tm1 ++ collectUnfolds rtp tm2
 collectUnfolds rtp (TmLet x xtm xtp tm tp) = collectUnfolds rtp xtm ++ collectUnfolds rtp tm
-collectUnfolds rtp (TmCase tm (y, _) cs tp) =
+collectUnfolds rtp (TmCase tm (y, _, _) cs tp) =
   let fvs = freeVars cs
       this = if y == rtp then [(fvs, tp)] else [] in
     collectUnfolds rtp tm
@@ -37,7 +37,7 @@ collectUnfolds rtp (TmEqs tms) = concatMap (collectUnfolds rtp) tms
 collectFolds :: Var -> Term -> [(Var, FreeVars)]
 collectFolds rtp (TmVarL x tp) = []
 collectFolds rtp (TmVarG gv x _ _ as tp) =
-  let this = if TpData rtp [] == tp && gv == CtorVar then [(x, freeVars (fsts as))] else [] in
+  let this = if TpData rtp [] [] == tp && gv == CtorVar then [(x, freeVars (fsts as))] else [] in
     concatMap (\ (atm, atp) -> collectFolds rtp atm) as ++ this
 collectFolds rtp (TmLam x tp tm tp') = collectFolds rtp tm
 collectFolds rtp (TmApp tm1 tm2 tp2 tp) = collectFolds rtp tm1 ++ collectFolds rtp tm2
@@ -76,8 +76,8 @@ makeUnfoldDatatype y us = ProgData (unfoldTypeName y) [Ctor (unfoldCtorName y) [
 -- Makes the "unapply" function and Unfold datatype
 makeDisentangle :: Ctxt -> Var -> [(FreeVars, Type)] -> [[Case]] -> (Prog, Prog)
 makeDisentangle g y us css =
-  let ytp = TpData y []
-      utp = TpData (unfoldTypeName y) []
+  let ytp = TpData y [] []
+      utp = TpData (unfoldTypeName y) [] []
       dat = makeUnfoldDatatype y us
       x = freshVar g targetName
       sub_ps ps = [(x, derefunSubst Refun y tp) | (x, tp) <- ps]
@@ -86,7 +86,7 @@ makeDisentangle g y us css =
                   g' = \ xps -> ctxtDeclArgs g (xps ++ ps)
                   cs' = [Case cx (sub_ps cps) (derefunTerm Refun (g' cps) y ctm)
                         | Case cx cps ctm <- cs] in
-                 (joinLams ps (TmCase (TmVarL x ytp) (y, []) cs' tp),
+                 (joinLams ps (TmCase (TmVarL x ytp) (y, [], []) cs' tp),
                    joinArrows (tpUnit : snds ps) tp)
              | (fvs, tp, cs, i) <- alls]
       fun = ProgFun (unfoldName y) [(x, ytp)] (TmVarG CtorVar (unfoldCtorName y) [] [] [(TmProd Additive cscs, TpProd Additive (snds cscs))] utp) utp -- (TpArr ytp utp)
@@ -99,16 +99,16 @@ makeDefold g y tms =
   let fname = applyName y
       tname = foldTypeName y
       x = freshVar g targetName
-      ftp = TpData tname []
+      ftp = TpData tname [] []
       ps = [(x, ftp)]
       casesf = \ (i, tm) -> let ps' = Map.toList (freeVars tm) in Case (foldCtorName y i) ps' (derefunTerm Defun (ctxtDeclArgs g ps') y tm)
       cases = map casesf (enumerate tms)
       ctors = [Ctor x (snds ps) | Case x ps tm <- cases]
-      tm = TmCase (TmVarL x ftp) (tname, []) cases (TpData y [])
+      tm = TmCase (TmVarL x ftp) (tname, [], []) cases (TpData y [] [])
   in
 --    error (tname ++ " | " ++ show ctors ++ " | " ++ show cases)
     (ProgData tname ctors,
-     ProgFun fname ps tm (TpData y []))
+     ProgFun fname ps tm (TpData y [] []))
 
 --------------------------------------------------
 
@@ -129,7 +129,7 @@ disentangleTerm rtp cases = h where
     pure TmApp <*> h tm1 <*> h tm2 <*> pure tp2 <*> pure tp
   h (TmLet x xtm xtp tm tp) =
     pure (TmLet x) <*> h xtm <*> pure xtp <*> h tm <*> pure tp
-  h (TmCase tm (y, _) cs tp)
+  h (TmCase tm (y, _, _) cs tp)
     | y == rtp =
       h tm >>= \ tm' ->
       mapCasesM (\ _ _ -> h) cs >>= \ cs' ->
@@ -143,12 +143,12 @@ disentangleTerm rtp cases = h where
           xtps = map get_arr cases
           xtp = TpProd Additive xtps
           cs'' = [Case (unfoldCtorName rtp) [(x', xtp)] (let cfvstp2 = cases !! i in joinApps (TmElimProd Additive (TmVarL x' xtp) [(if j == i then x'' else "_", jtp) | (j, jtp) <- enumerate xtps] (TmVarL x'' (xtps !! i)) (xtps !! i)) (get_as cfvstp2))]
-          rtm = TmCase tm (unfoldTypeName rtp, []) cs'' tp
+          rtm = TmCase tm (unfoldTypeName rtp, [], []) cs'' tp
       in
         State.put (unfolds ++ [cs']) >>
         pure rtm
     | otherwise =
-      pure TmCase <*> h tm <*> pure (y, []) <*> mapCasesM (\ _ _ -> h) cs <*> pure tp
+      pure TmCase <*> h tm <*> pure (y, [], []) <*> mapCasesM (\ _ _ -> h) cs <*> pure tp
   h (TmAmb tms tp) =
     pure TmAmb <*> mapM h tms <*> pure tp
   h (TmFactor wt tm tp) =
@@ -173,17 +173,17 @@ defoldTerm rtp = h where
   h :: Term -> DefoldM Term
   h (TmVarL x tp) = pure (TmVarL x tp)
   h (TmVarG gv x _ _ as tp)
-    | gv == CtorVar && tp == TpData rtp [] =
+    | gv == CtorVar && tp == TpData rtp [] [] =
         mapArgsM h as >>= \ as' ->
         State.get >>= \ fs ->
         let fvs = Map.toList (freeVars (fsts as'))
             cname = foldCtorName rtp (length fs)
             tname = foldTypeName rtp
             aname = applyName rtp
-            fld = TmVarG CtorVar cname [] [] (paramsToArgs fvs) (TpData tname [])
+            fld = TmVarG CtorVar cname [] [] (paramsToArgs fvs) (TpData tname [] [])
         in
-          State.put (fs ++ [TmVarG CtorVar x [] [] as' (TpData rtp [])]) >>
-          return (TmVarG DefVar aname [] [] [(fld, TpData tname [])] (TpData rtp []))
+          State.put (fs ++ [TmVarG CtorVar x [] [] as' (TpData rtp [] [])]) >>
+          return (TmVarG DefVar aname [] [] [(fld, TpData tname [] [])] (TpData rtp [] []))
     | otherwise = pure (TmVarG gv x [] []) <*> mapArgsM h as <*> pure tp
   h (TmLam x tp tm tp') = pure (TmLam x tp) <*> h tm <*> pure tp'
   h (TmApp tm1 tm2 tp2 tp) = pure TmApp <*> h tm1 <*> h tm2 <*> pure tp2 <*> pure tp
@@ -234,8 +234,8 @@ derefunTerm dr g rtp = fst . h where
   h' :: Term -> Term
   h' (TmVarL x tp) = let tp' = sub tp in TmVarL x tp'
   h' (TmVarG gv x _ _ as tp)
-    | dr == Refun && gv == CtorVar && tp == TpData rtp [] =
-      TmVarG DefVar unfoldN [] [] [(TmVarG gv x [] [] (h_as as) tp, tp)] (TpData unfoldTypeN [])
+    | dr == Refun && gv == CtorVar && tp == TpData rtp [] [] =
+      TmVarG DefVar unfoldN [] [] [(TmVarG gv x [] [] (h_as as) tp, tp)] (TpData unfoldTypeN [] [])
     | dr == Defun && gv == DefVar && x == applyN =
       let [(etm, etp)] = as in h' etm
     | otherwise =
@@ -255,17 +255,17 @@ derefunTerm dr g rtp = fst . h where
     let (xtm', xtp') = h xtm
         (tm', tp') = h tm in
     TmLet x xtm' xtp' tm' tp'
-  h' (TmCase tm1 (tp1, _) cs tp2)
+  h' (TmCase tm1 (tp1, _, _) cs tp2)
     | dr == Defun && tp1 == rtp =
         let (tm1', tp1') = h tm1
             cs' = [Case x (h_ps ps) (fst (h xtm)) | Case x ps xtm <- cs]
             tp2' = case cs' of [] -> sub tp2; (Case x ps xtm : _) -> typeof xtm in
-          TmCase (TmVarG DefVar applyN [] [] [(tm1', tp1')] (TpData rtp [])) (rtp, []) cs' tp2'
+          TmCase (TmVarG DefVar applyN [] [] [(tm1', tp1')] (TpData rtp [] [])) (rtp, [], []) cs' tp2'
     | otherwise =
-        let (tm1', TpData tp1' []) = h tm1
+        let (tm1', TpData tp1' [] []) = h tm1
             cs' = [Case x (h_ps ps) (fst (h xtm)) | Case x ps xtm <- cs]
             tp2' = case cs' of [] -> sub tp2; (Case x ps xtm : _) -> typeof xtm in
-          TmCase tm1' (tp1', []) cs' tp2'
+          TmCase tm1' (tp1', [], []) cs' tp2'
   h' (TmAmb tms tp) =
     let tms' = map h tms
         tp' = if null tms' then sub tp else snd (head tms') in
@@ -306,7 +306,6 @@ derefun dr rtp new_ps (Progs ps end) =
       --emsg = "Failed to " ++ dr' ++ " " ++ rtp
   in
     return (Progs rps rtm)
---    maybe (return (Progs rps rtm)) (\ datahist -> Left (emsg ++ ":\n" ++ intercalate "\n" [show (UsProgData y cs) | (y, cs) <- datahist])) (isInfiniteType' (ctxtDefProgs (Progs (rps ++ new_ps) rtm)) (TpData rtp)) -- then Left emsg else return (Progs rps rtm)
 
 derefunThis :: DeRe -> Var -> Progs -> (Progs, Prog, Prog)
 derefunThis Defun rtp ps =
@@ -352,7 +351,7 @@ data RecDeps = RecDeps { defunDeps :: [Var], refunDeps :: [Var] }
 type RecEdges = Map Var RecDeps
 
 recDeps :: Ctxt -> [Var] -> Type -> [Var]
-recDeps g recs (TpData y _)
+recDeps g recs (TpData y _ _)
   | y `elem` recs = [y]
   | otherwise = maybe []
       (nub . concatMap (\ (Ctor _ tps) -> concatMap (recDeps g recs) tps))

--- a/src/Transform/Monomorphize.hs
+++ b/src/Transform/Monomorphize.hs
@@ -21,11 +21,11 @@ semimap (Semimap m) = m
 
 -- Maps a definition name to the instantiations it has
 -- (where each inst is a list of types, one for each tag/type var)
-type Insts = Semimap Var (Set.Set [Type])
+type Insts = Semimap Var (Set.Set ([Type], [Type]))
 -- Map a definition to the tag and type vars it is polymorphic over
 type TypeParams = Map Var ([Var], [Var])
 -- List of global calls something makes, and the instantiation of each call
-type GlobalCalls = [(Var, [Type])]
+type GlobalCalls = [(Var, [Type], [Type])]
 -- Maps a definition name to all the other defs it calls and how it instantiates them
 type DefMap = Map Var GlobalCalls
 
@@ -37,7 +37,7 @@ collectCalls' :: Term -> GlobalCalls
 collectCalls' (TmVarL x tp) =
   collectCallsTp tp
 collectCalls' (TmVarG g x tgs tis as tp) =
-  [(x, tgs++tis)] <> mconcat (collectCalls <$> fsts as)
+  [(x, tgs, tis)] <> mconcat (collectCalls <$> fsts as)
 collectCalls' (TmLam x xtp tm tp) =
   collectCalls tm
 collectCalls' (TmApp tm1 tm2 tp2 tp) =
@@ -59,7 +59,7 @@ collectCalls' (TmEqs tms) =
 
 -- Collects datatype calls in a type
 collectCallsTp :: Type -> GlobalCalls
-collectCallsTp (TpData y tgs as) = [(y, tgs++as)] <> mconcat (map collectCallsTp as)
+collectCallsTp (TpData y tgs as) = [(y, tgs, as)] <> mconcat (map collectCallsTp as)
 collectCallsTp (TpArr tp1 tp2)   = collectCallsTp tp1 <> collectCallsTp tp2
 collectCallsTp (TpProd am tps)   = mconcat (map collectCallsTp tps)
 collectCallsTp  _                = []
@@ -70,12 +70,12 @@ collectCallsTp  _                = []
 --  and `reverse1 : List1 -> List1` and `reverse2 : List2 -> List2`; then, replace all
 --  calls to `reverse` for a List Bool with `reverse1` and similarly for `reverse2`
 --  with calls to List Unit)
-renameCalls :: Map Var (Map [Type] Int) -> Term -> Term
+renameCalls :: Map Var (Map ([Type], [Type]) Int) -> Term -> Term
 renameCalls xis (TmVarL x tp) = TmVarL x (renameCallsTp xis tp)
 renameCalls xis (TmVarG g x [] [] as tp) = TmVarG g x [] [] [(renameCalls xis tm, renameCallsTp xis tp) | (tm, tp) <- as] (renameCallsTp xis tp)
 renameCalls xis (TmVarG g x tgs tis as tp) =
   let xisx = xis Map.! x
-      xi = (xis Map.! x) Map.! (tgs++tis)
+      xi = (xis Map.! x) Map.! (tgs, tis)
   in
     TmVarG g (instName x xi) [] []
       [(renameCalls xis tm, renameCallsTp xis tp)| (tm, tp) <- as]
@@ -84,7 +84,7 @@ renameCalls xis (TmLam x xtp tm tp) = TmLam x (renameCallsTp xis xtp) (renameCal
 renameCalls xis (TmApp tm1 tm2 tp2 tp) = TmApp (renameCalls xis tm1) (renameCalls xis tm2) (renameCallsTp xis tp2) (renameCallsTp xis tp)
 renameCalls xis (TmLet x xtm xtp tm tp) = TmLet x (renameCalls xis xtm) (renameCallsTp xis xtp) (renameCalls xis tm) (renameCallsTp xis tp)
 renameCalls xis (TmCase tm (y, tgs, as) cs tp) =
-  let yi = (if null (tgs++as) then Nothing else Just ()) >> xis Map.!? y >>= \ m -> m Map.!? (tgs++as)
+  let yi = (if null tgs && null as then Nothing else Just ()) >> xis Map.!? y >>= \ m -> m Map.!? (tgs, as)
       (y', tgs', as') = maybe (y, tgs, as) (\ i -> (instName y i, [], [])) yi
   in
     TmCase (renameCalls xis tm) (y', tgs', as')
@@ -96,11 +96,11 @@ renameCalls xis (TmElimProd am ptm ps tm tp) = TmElimProd am (renameCalls xis pt
 renameCalls xis (TmEqs tms) = TmEqs (renameCalls xis <$> tms)
 
 -- Same as renameCalls, but for types
-renameCallsTp :: Map Var (Map [Type] Int) -> Type -> Type
+renameCallsTp :: Map Var (Map ([Type], [Type]) Int) -> Type -> Type
 renameCallsTp xis (TpData y [] []) = TpData y [] [] -- a datatype with no arguments can have only one instantiation, so we don't rename it (see makeInstantiations))
 renameCallsTp xis (TpData y tgs as) =
   maybe (TpData y tgs as)
-    (\ m -> let yi = m Map.! (tgs++as) in TpData (instName y yi) [] [])
+    (\ m -> let yi = m Map.! (tgs, as) in TpData (instName y yi) [] [])
     (xis Map.!? y)
 renameCallsTp xis (TpArr tp1 tp2) = TpArr (renameCallsTp xis tp1) (renameCallsTp xis tp2)
 renameCallsTp xis (TpProd am tps) = TpProd am (map (renameCallsTp xis) tps)
@@ -131,28 +131,29 @@ makeTypeParams = mconcat . map h where
   h (SProgData y tgs ps cs) = Map.fromList ((y, (tgs, ps)) : map (\ (Ctor x tps) -> (x, (tgs, ps))) cs)
 
 -- If not visited, insert into Insts and recurse
-addInsts :: DefMap -> TypeParams -> Insts -> Var -> [Type] -> Insts
-addInsts dm tpms xis x tis
+addInsts :: DefMap -> TypeParams -> Insts -> Var -> [Type] -> [Type] -> Insts
+addInsts dm tpms xis x tgs tis
   -- if already visited, or not polymorphic in the first place, just return xis
-  | not (x `Map.member` semimap xis) || tis `Set.member` (semimap xis Map.! x) = xis
+  | not (x `Map.member` semimap xis) || (tgs,tis) `Set.member` (semimap xis Map.! x) = xis
   | otherwise = processNext x dm tpms
-                  (xis <> Semimap (Map.singleton x (Set.singleton tis))) x tis
+                  (xis <> Semimap (Map.singleton x (Set.singleton (tgs,tis)))) x tgs tis
   where
     -- Depth-first traversal with cur as root
-    processNext :: Var -> DefMap -> TypeParams -> Insts -> Var -> [Type] -> Insts
-    processNext cur dm tpms xis x tis =
+    processNext :: Var -> DefMap -> TypeParams -> Insts -> Var -> [Type] -> [Type] -> Insts
+    processNext cur dm tpms xis x tgs tis =
       let (curtgs, curpms) = tpms Map.! cur
           curtis = semimap xis Map.! cur
-          mksub = \ ctis -> Map.fromList (zip (curtgs ++ curpms) (SubTp <$> ctis))
       in
-        foldr (\ (x, tis) xis ->
-                  foldr (\ ctis xis ->
-                            addInsts dm tpms xis x (subst (mksub ctis) tis))
+        foldr (\ (x, tgs, tis) xis ->
+                  foldr (\ (ctgs,ctis) xis ->
+                            addInsts dm tpms xis x
+                                     (subst (Map.fromList (pickyZip curtgs (SubTp <$> ctgs))) tgs)
+                                     (subst (Map.fromList (pickyZip curpms (SubTp <$> ctis))) tis))
                         xis curtis)
               xis (dm Map.! x)
 
 -- Given a map from def name to its instance names, duplicate a def for each instantation
-makeInstantiations :: Map Var (Map [Type] Int) -> SProg -> [Prog]
+makeInstantiations :: Map Var (Map ([Type], [Type]) Int) -> SProg -> [Prog]
 makeInstantiations xis (SProgFun x [] [] tp tm) =
   if null (Map.toList (xis Map.! x)) then
     -- if x is never instantiated even with [] (since it has no tags/type vars),
@@ -162,8 +163,9 @@ makeInstantiations xis (SProgFun x [] [] tp tm) =
     [ProgFun x [] (renameCalls xis tm) (renameCallsTp xis tp)]
 makeInstantiations xis (SProgFun x tgs ys tp tm) =
   let tiss = Map.toList (xis Map.! x) in
-    map (\ (tis, i) ->
-           let s = Map.fromList (zip (tgs ++ ys) (SubTp <$> tis)) in
+    map (\ ((tags, tis), i) ->
+           let s = Map.fromList (pickyZip tgs (SubTp <$> tags) ++
+                                 pickyZip ys  (SubTp <$> tis )) in
              ProgFun
                (instName x i) -- new name for this particular instantiation
                [] -- args are [], for now (see Transform.Argify)
@@ -183,8 +185,9 @@ makeInstantiations xis (SProgData y [] [] cs) =
     [ProgData y [Ctor x (map (renameCallsTp xis) tps) | Ctor x tps <- cs]]
 makeInstantiations xis (SProgData y tgs ps cs) =
     let tiss = Map.toList (xis Map.! y) in
-    map (\ (tis, i) ->
-           let s = Map.fromList (zip (tgs ++ ps) (SubTp <$> tis)) in
+    map (\ ((tags, tis), i) ->
+           let s = Map.fromList (pickyZip tgs (SubTp <$> tags) ++
+                                 pickyZip ps  (SubTp <$> tis )) in
              ProgData
                (instName y i) -- new name for this particular instantiation
                [Ctor (instName x i) (map (renameCallsTp xis) (subst s tps))
@@ -197,7 +200,7 @@ makeInstantiations xis (SProgData y tgs ps cs) =
 -- of their datatype. This avoids generating mismatched/confusing datatypes
 -- and constructors like:
 --   data Nat_inst0 = Zero_inst5 | Succ_inst2
-overrideCtorInsts :: Map Var (Map [Type] Int) -> [SProg] -> Map Var (Map [Type] Int)
+overrideCtorInsts :: Map Var (Map ([Type], [Type]) Int) -> [SProg] -> Map Var (Map ([Type], [Type]) Int)
 overrideCtorInsts m [] = m
 overrideCtorInsts m (SProgData y tgs pms cs : sps) =
   let yis = m Map.! y
@@ -212,7 +215,7 @@ monomorphizeFile (SProgs sps stm) =
   let dm = makeDefMap sps
       tpms = makeTypeParams sps
       xis = makeEmptyInsts sps
-      xis' = foldr (\ (x, tis) xis -> addInsts dm tpms xis x tis) xis (collectCalls stm)
+      xis' = foldr (\ (x, tis, as) xis -> addInsts dm tpms xis x tis as) xis (collectCalls stm)
       xis'' = fmap (\ tiss -> Map.fromList (zip (Set.toList tiss) [0..])) (semimap xis')
       xis''' = overrideCtorInsts xis'' sps
   in

--- a/src/Transform/Monomorphize.hs
+++ b/src/Transform/Monomorphize.hs
@@ -161,11 +161,11 @@ makeInstantiations xis (SProgFun x [] [] tm tp) =
     []
   else
     [ProgFun x [] (renameCalls xis tm) (renameCallsTp xis tp)]
-makeInstantiations xis (SProgFun x tgs ys tm tp) =
+makeInstantiations xis (SProgFun x tgs ps tm tp) =
   let tiss = Map.toList (xis Map.! x) in
-    map (\ ((tags, tis), i) ->
-           let s = Map.fromList (pickyZip tgs (SubTp <$> tags) ++
-                                 pickyZip ys  (SubTp <$> tis )) in
+    map (\ ((tgs', tis), i) ->
+           let s = Map.fromList (pickyZip tgs (SubTp <$> tgs') ++
+                                 pickyZip ps  (SubTp <$> tis )) in
              ProgFun
                (instName x i) -- new name for this particular instantiation
                [] -- args are [], for now (see Transform.Argify)

--- a/src/Transform/Monomorphize.hs
+++ b/src/Transform/Monomorphize.hs
@@ -215,7 +215,7 @@ monomorphizeFile (SProgs sps stm) =
   let dm = makeDefMap sps
       tpms = makeTypeParams sps
       xis = makeEmptyInsts sps
-      xis' = foldr (\ (x, tis, as) xis -> addInsts dm tpms xis x tis as) xis (collectCalls stm)
+      xis' = foldr (\ (x, tgs, tis) xis -> addInsts dm tpms xis x tgs tis) xis (collectCalls stm)
       xis'' = fmap (\ tiss -> Map.fromList (zip (Set.toList tiss) [0..])) (semimap xis')
       xis''' = overrideCtorInsts xis'' sps
   in

--- a/src/Transform/Monomorphize.hs
+++ b/src/Transform/Monomorphize.hs
@@ -83,11 +83,11 @@ renameCalls xis (TmVarG g x tgs tis as tp) =
 renameCalls xis (TmLam x xtp tm tp) = TmLam x (renameCallsTp xis xtp) (renameCalls xis tm) (renameCallsTp xis tp)
 renameCalls xis (TmApp tm1 tm2 tp2 tp) = TmApp (renameCalls xis tm1) (renameCalls xis tm2) (renameCallsTp xis tp2) (renameCallsTp xis tp)
 renameCalls xis (TmLet x xtm xtp tm tp) = TmLet x (renameCalls xis xtm) (renameCallsTp xis xtp) (renameCalls xis tm) (renameCallsTp xis tp)
-renameCalls xis (TmCase tm (y, tgs, tis) cs tp) =
-  let yi = (if null (tgs++tis) then Nothing else Just ()) >> xis Map.!? y >>= \ m -> m Map.!? (tgs++tis)
-      (y', tgs', tis') = maybe (y, tgs, tis) (\ i -> (instName y i, [], [])) yi
+renameCalls xis (TmCase tm (y, tgs, as) cs tp) =
+  let yi = (if null (tgs++as) then Nothing else Just ()) >> xis Map.!? y >>= \ m -> m Map.!? (tgs++as)
+      (y', tgs', as') = maybe (y, tgs, as) (\ i -> (instName y i, [], [])) yi
   in
-    TmCase (renameCalls xis tm) (y', tgs', tis')
+    TmCase (renameCalls xis tm) (y', tgs', as')
       (fmap (\ (Case x ps tm') -> Case (maybe x (instName x) yi) [(x', renameCallsTp xis tp) | (x', tp) <- ps] (renameCalls xis tm')) cs) (renameCallsTp xis tp)
 renameCalls xis (TmAmb tms tp) = TmAmb (renameCalls xis <$> tms) (renameCallsTp xis tp)
 renameCalls xis (TmFactor wt tm tp) = TmFactor wt (renameCalls xis tm) (renameCallsTp xis tp)

--- a/src/Transform/Monomorphize.hs
+++ b/src/Transform/Monomorphize.hs
@@ -59,10 +59,10 @@ collectCalls' (TmEqs tms) =
 
 -- Collects datatype calls in a type
 collectCallsTp :: Type -> GlobalCalls
-collectCallsTp (TpData y tgs tis) = [(y, tgs++tis)] <> mconcat (map collectCallsTp tis)
-collectCallsTp (TpArr tp1 tp2)    = collectCallsTp tp1 <> collectCallsTp tp2
-collectCallsTp (TpProd am tps)    = mconcat (map collectCallsTp tps)
-collectCallsTp  _                 = []
+collectCallsTp (TpData y tgs as) = [(y, tgs++as)] <> mconcat (map collectCallsTp as)
+collectCallsTp (TpArr tp1 tp2)   = collectCallsTp tp1 <> collectCallsTp tp2
+collectCallsTp (TpProd am tps)   = mconcat (map collectCallsTp tps)
+collectCallsTp  _                = []
 
 -- Substitutes polymorphic calls for their monomorphized version
 -- (So if we instantiate List with Bool and Unit, then `List1 = List Bool` and
@@ -98,9 +98,9 @@ renameCalls xis (TmEqs tms) = TmEqs (renameCalls xis <$> tms)
 -- Same as renameCalls, but for types
 renameCallsTp :: Map Var (Map [Type] Int) -> Type -> Type
 renameCallsTp xis (TpData y [] []) = TpData y [] [] -- a datatype with no arguments can have only one instantiation, so we don't rename it (see makeInstantiations))
-renameCallsTp xis (TpData y tgs tis) =
-  maybe (TpData y tgs tis)
-    (\ m -> let yi = m Map.! (tgs++tis) in TpData (instName y yi) [] [])
+renameCallsTp xis (TpData y tgs as) =
+  maybe (TpData y tgs as)
+    (\ m -> let yi = m Map.! (tgs++as) in TpData (instName y yi) [] [])
     (xis Map.!? y)
 renameCallsTp xis (TpArr tp1 tp2) = TpArr (renameCallsTp xis tp1) (renameCallsTp xis tp2)
 renameCallsTp xis (TpProd am tps) = TpProd am (map (renameCallsTp xis) tps)

--- a/src/Transform/Optimize.hs
+++ b/src/Transform/Optimize.hs
@@ -49,9 +49,9 @@ Notes:
 -- p(result==z) = p(b==true)
 liftAmb :: Term -> Term
 liftAmb (TmVarL x tp) = TmVarL x tp
-liftAmb (TmVarG gv x tis as tp) =
+liftAmb (TmVarG gv x tgs tis as tp) =
   let as' = [[(atm', atp) | atm' <- splitAmbs (liftAmb atm)] | (atm, atp) <- as] in
-    joinAmbs [TmVarG gv x tis as tp | as <- (kronall as')] tp
+    joinAmbs [TmVarG gv x tgs tis as tp | as <- (kronall as')] tp
 liftAmb (TmLam x tp tm tp') =
   joinAmbs [TmLam x tp tm tp' | tm <- splitAmbs (liftAmb tm)] (TpArr tp tp') 
 liftAmb (TmApp tm1 tm2 tp2 tp) =
@@ -101,8 +101,8 @@ liftFail'' (tm, Just tm') = tm'
 
 liftFail' :: Term -> Maybe Term
 liftFail' (TmVarL x tp) = pure (TmVarL x tp)
-liftFail' (TmVarG gv x tis as tp) =
-  pure (TmVarG gv x tis) <*> mapArgsM liftFail' as <*> pure tp
+liftFail' (TmVarG gv x tgs tis as tp) =
+  pure (TmVarG gv x tgs tis) <*> mapArgsM liftFail' as <*> pure tp
 liftFail' (TmLam x tp tm tp') = pure (TmLam x tp (liftFail tm) tp')
 liftFail' (TmApp tm1 tm2 tp2 tp) = pure TmApp <*> liftFail' tm1 <*> liftFail' tm2 <*> pure tp2 <*> pure tp
 liftFail' (TmLet x xtm xtp tm tp) =
@@ -164,7 +164,7 @@ safe2sub g x xtm tm =
     -- Returns if there are no global def vars or ambs/fails/uniforms
     noDefsSamps :: Term -> Bool
     noDefsSamps (TmVarL x tp) = True
-    noDefsSamps (TmVarG g x _ as tp) = g == CtorVar && all (noDefsSamps . fst) as
+    noDefsSamps (TmVarG g x _ _ as tp) = g == CtorVar && all (noDefsSamps . fst) as
     noDefsSamps (TmLam x tp tm tp') = noDefsSamps tm
     noDefsSamps (TmApp tm1 tm2 tp2 tp) = noDefsSamps tm1 && noDefsSamps tm2
     noDefsSamps (TmLet x xtm xtp tm tp) = noDefsSamps xtm && noDefsSamps tm
@@ -179,8 +179,8 @@ safe2sub g x xtm tm =
 -- Applies various optimizations to a term
 optimizeTerm :: Ctxt -> Term -> Term
 optimizeTerm g (TmVarL x tp) = TmVarL x tp
-optimizeTerm g (TmVarG gv x tis as tp) =
-  TmVarG gv x tis (optimizeArgs g as) tp
+optimizeTerm g (TmVarG gv x tgs tis as tp) =
+  TmVarG gv x tgs tis (optimizeArgs g as) tp
 optimizeTerm g (TmLet x xtm xtp tm tp) =
   let xtm' = optimizeTerm g xtm
       tm' = optimizeTerm (ctxtDefLocal g x xtp) tm in
@@ -207,7 +207,7 @@ optimizeTerm g (TmApp tm1 tm2 tp2 tp) =
 optimizeTerm g (TmCase tm y cs tp) =
   let tm' = optimizeTerm g tm in
     case splitLets tm' of
-      (ds, TmVarG CtorVar x tis as _) ->
+      (ds, TmVarG CtorVar x tgs tis as _) ->
         let [Case _ cps ctm] = filter (\ (Case x' _ _) -> x == x') cs
             p_a_ds = zipWith (\ (tm, _) (x', tp) -> (x', tm, tp)) as cps in
           optimizeTerm g (joinLets (ds ++ p_a_ds) ctm)

--- a/src/TypeInf/Check.hs
+++ b/src/TypeInf/Check.hs
@@ -257,13 +257,13 @@ annTp tp = checkType tp
 checkType :: Type -> CheckM Type
 checkType (TpArr tp1 tp2) =
   pure TpArr <*> checkType tp1 <*> checkType tp2
-checkType (TpData y [] tis) =
-  lookupDatatype y >>= \ (tgs, tpvars, _) ->
-  mapM checkType tis >>= \ tis' ->
+checkType (TpData y [] as) =
+  lookupDatatype y >>= \ (tgs, ps, _) ->
+  mapM checkType as >>= \ as' ->
   mapM (const freshTag) tgs >>= \ tgs' ->
-  guardM (length tis == length tpvars) (WrongNumArgs (length tpvars) (length tis)) >>
-  pure (TpData y tgs' tis')
-checkType (TpData y tgs tis) =
+  guardM (length as == length ps) (WrongNumArgs (length ps) (length as)) >>
+  pure (TpData y tgs' as')
+checkType (TpData y tgs as) =
   error "checkType should never see a tag!"
 checkType (TpProd am tps) =
   pure (TpProd am) <*> mapM checkType tps

--- a/src/TypeInf/Check.hs
+++ b/src/TypeInf/Check.hs
@@ -194,7 +194,7 @@ lookupCtorType (CaseUs x _ _ : _) =
   lookupTermVar x >>= \ d ->
   case d of
     DefCtor _ _ ctp -> case splitArrows ctp of
-      (_, TpData y _) -> lookupDatatype y >>= \ (tgs, xs, cs) -> return (y, tgs, xs, cs)
+      (_, TpData y _ _) -> lookupDatatype y >>= \ (tgs, xs, cs) -> return (y, tgs, xs, cs)
       (_, etp) -> error "This shouldn't happen"
     _ -> err (CtorError x)
 
@@ -257,12 +257,14 @@ annTp tp = checkType tp
 checkType :: Type -> CheckM Type
 checkType (TpArr tp1 tp2) =
   pure TpArr <*> checkType tp1 <*> checkType tp2
-checkType (TpData y as) =
-  lookupDatatype y >>= \ (tgs, ps, _) ->
-  mapM checkType as >>= \ as' ->
+checkType (TpData y [] tis) =
+  lookupDatatype y >>= \ (tgs, tpvars, _) ->
+  mapM checkType tis >>= \ tis' ->
   mapM (const freshTag) tgs >>= \ tgs' ->
-  guardM (length ps == length as) (WrongNumArgs (length ps) (length as)) >>
-  pure (TpData y (tgs' ++ as'))
+  guardM (length tis == length tpvars) (WrongNumArgs (length tpvars) (length tis)) >>
+  pure (TpData y tgs' tis')
+checkType (TpData y tgs tis) =
+  error "checkType should never see a tag!"
 checkType (TpProd am tps) =
   pure (TpProd am) <*> mapM checkType tps
 checkType (TpVar y) =
@@ -294,7 +296,7 @@ infer' (UsVar x) =
       mapM (const freshTp) tis >>= \ tis' ->
       -- substitute old tags/type vars for new ones
       let tp' = subst (Map.fromList (zip (tgs ++ tis) (SubTp <$> (tgs' ++ tis')))) tp in
-        return (TmVarG gv x (tgs' ++ tis') [] tp')
+        return (TmVarG gv x tgs' tis' [] tp')
 
 infer' (UsLam x xtp tm) =
   -- Check the annotation xtp
@@ -333,14 +335,14 @@ infer' (UsCase tm cs) =
   guardM (length ctors == length cs) (WrongNumCases (length ctors) (length cs)) >>
   infer tm >>= \ tm' ->
   -- Constraint: (y itgs ips) = (typeof tm')
-  constrain (Unify (TpData y (itgs ++ ips)) (typeof tm')) >>
+  constrain (Unify (TpData y itgs ips) (typeof tm')) >>
   -- itp = cases return type
   freshTp >>= \ itp ->
   -- infer cases
   mapM (uncurry inferCase) (zip cs' ctors') >>= \ cs'' ->
   -- Constraints: for each case `| x ps -> tm`, itp = (typeof tm)
   mapM (\ (Case x ps tm) -> constrain (Unify itp (typeof tm))) cs'' >>
-  return (TmCase tm' (y, itgs ++ ips) cs'' itp)
+  return (TmCase tm' (y, itgs, ips) cs'' itp)
 
 infer' (UsIf tm1 tm2 tm3) =
   infer tm1 >>= \ tm1' ->
@@ -351,11 +353,11 @@ infer' (UsIf tm1 tm2 tm3) =
   -- Constraint: (typeof tm2') = (typeof tm3')
   constrain (Unify (typeof tm2') (typeof tm3')) >>
   -- Translate if-then-else to case-of
-  return (TmCase tm1' (tpBoolName, []) [Case tmFalseName [] tm3', Case tmTrueName [] tm2'] (typeof tm2'))
+  return (TmCase tm1' (tpBoolName, [], []) [Case tmFalseName [] tm3', Case tmTrueName [] tm2'] (typeof tm2'))
 
 infer' (UsTmBool b) =
   -- Translate True/False into a constructor var
-  return (TmVarG CtorVar (if b then tmTrueName else tmFalseName) [] [] tpBool)
+  return (TmVarG CtorVar (if b then tmTrueName else tmFalseName) [] [] [] tpBool)
 
 infer' (UsLet x xtm tm) =
   -- Check the annotation xtp'

--- a/src/TypeInf/Solve.hs
+++ b/src/TypeInf/Solve.hs
@@ -24,9 +24,9 @@ bindTp x tp
 unify :: Type -> Type -> Either TypeError Subst
 unify (TpVar y) tp = bindTp y tp
 unify tp (TpVar y) = bindTp y tp
-unify tp1@(TpData y1 tgs1 tis1) tp2@(TpData y2 tgs2 tis2)
-  | y1 == y2 && length tgs1 == length tgs2 && length tis1 == length tis2 =
-      unifyAll' (zip (tgs1++tis1) (tgs2++tis2))
+unify tp1@(TpData y1 tgs1 as1) tp2@(TpData y2 tgs2 as2)
+  | y1 == y2 && length tgs1 == length tgs2 && length as1 == length as2 =
+      unifyAll' (zip (tgs1++as1) (tgs2++as2))
   | otherwise = Left (UnificationError tp1 tp2)
 unify (TpArr l1 r1) (TpArr l2 r2) =
   unify l1 l2 >>= \ sl ->
@@ -293,9 +293,12 @@ inferData dsccs cont = foldr h cont dsccs
     constrainTpApps :: Type -> CheckM ()
     constrainTpApps (TpArr tp1 tp2) = constrainTpApps tp1 >> constrainTpApps tp2
     constrainTpApps (TpVar y) = return ()
-    constrainTpApps (TpData y tgs tis) =
-      lookupDatatype y >>= \ (tgvars, tpvars, _) ->
-        zipWithM_ (\ x a -> constrain (Unify (TpVar x) a)) (tgvars++tpvars) (tgs++tis)
+    constrainTpApps (TpData y [] as) =
+      lookupDatatype y >>= \ (_, ps, _) ->
+        guardM (length ps == length as) (WrongNumArgs (length ps) (length as)) >>
+        zipWithM_ (\ x a -> constrain (Unify (TpVar x) a)) ps as
+    constrainTpApps (TpData y tgs as) =
+      error "constrainTpApps wasn't expecting to see tags"
     constrainTpApps (TpProd am tps) = mapM_ constrainTpApps tps
     constrainTpApps NoTp = error "this shouldn't happen"
 

--- a/src/TypeInf/Solve.hs
+++ b/src/TypeInf/Solve.hs
@@ -24,9 +24,9 @@ bindTp x tp
 unify :: Type -> Type -> Either TypeError Subst
 unify (TpVar y) tp = bindTp y tp
 unify tp (TpVar y) = bindTp y tp
-unify tp1@(TpData y1 as1) tp2@(TpData y2 as2)
-  | y1 == y2 && length as1 == length as2 =
-      unifyAll' (zip as1 as2)
+unify tp1@(TpData y1 tgs1 tis1) tp2@(TpData y2 tgs2 tis2)
+  | y1 == y2 && length tgs1 == length tgs2 && length tis1 == length tis2 =
+      unifyAll' (zip (tgs1++tis1) (tgs2++tis2))
   | otherwise = Left (UnificationError tp1 tp2)
 unify (TpArr l1 r1) (TpArr l2 r2) =
   unify l1 l2 >>= \ sl ->
@@ -153,7 +153,7 @@ solvesM ms =
 
         -- Add tag/type parameters to right-hand side terms. This has
         -- to be done in a second pass because of mutual recursion.
-        s' = Map.fromList [(f, SubTm (TmVarG DefVar f (TpVar <$> (tgs++xs')) [] tp')) | (f, _, tgs, xs', tp') <- defs']
+        s' = Map.fromList [(f, SubTm (TmVarG DefVar f (TpVar <$> tgs) (TpVar <$> xs') [] tp')) | (f, _, tgs, xs', tp') <- defs']
         defs'' = [(f, subst s' tm', tgs, xs', tp') | (f, tm', tgs, xs', tp') <- defs']
       in
         return defs''
@@ -293,9 +293,9 @@ inferData dsccs cont = foldr h cont dsccs
     constrainTpApps :: Type -> CheckM ()
     constrainTpApps (TpArr tp1 tp2) = constrainTpApps tp1 >> constrainTpApps tp2
     constrainTpApps (TpVar y) = return ()
-    constrainTpApps (TpData y as) =
-      lookupDatatype y >>= \ (_, xs, _) ->
-        zipWithM_ (\ x a -> constrain (Unify (TpVar x) a)) xs as
+    constrainTpApps (TpData y tgs tis) =
+      lookupDatatype y >>= \ (tgvars, tpvars, _) ->
+        zipWithM_ (\ x a -> constrain (Unify (TpVar x) a)) (tgvars++tpvars) (tgs++tis)
     constrainTpApps (TpProd am tps) = mapM_ constrainTpApps tps
     constrainTpApps NoTp = error "this shouldn't happen"
 
@@ -335,7 +335,7 @@ inferData dsccs cont = foldr h cont dsccs
          defDataSCC dscc (mapM_ constrainData dscc)) >>
       -- Add tag vars in vs to the recursive uses of types in dscc.
       let tgs = Map.keys (Map.filter id vs)
-          s = Map.fromList [(y, SubTp (TpData y (TpVar <$> tgs))) | (y, ps, cs) <- dscc']
+          s = Map.fromList [(y, SubTp (TpData y (TpVar <$> tgs) [])) | (y, ps, cs) <- dscc']
       in
         return [(y, tgs, ps, mapCtors (subst s) cs) | (y, ps, cs) <- dscc']
 

--- a/src/TypeInf/Solve.hs
+++ b/src/TypeInf/Solve.hs
@@ -336,7 +336,9 @@ inferData dsccs cont = foldr h cont dsccs
         -- type variables ps have already been renamed apart in alphaRenameProgs
         (mapM_ (\ (y, ps, cs) -> mapM_ addSolveTpVar ps) dscc >>
          defDataSCC dscc (mapM_ constrainData dscc)) >>
-      -- Add tag vars in vs to the recursive uses of types in dscc.
+      -- Add tag vars in vs to the recursive uses of types in dscc
+      -- by substituting y := y tgs.
+      
       let tgs = Map.keys (Map.filter id vs)
           s = Map.fromList [(y, SubTp (TpData y (TpVar <$> tgs) [])) | (y, ps, cs) <- dscc']
       in

--- a/src/Util/Helpers.hs
+++ b/src/Util/Helpers.hs
@@ -87,6 +87,9 @@ pickyZipWith f = go where
   go (a:as) (b:bs) = f a b : go as bs
   go _      _      = error "pickyZipWith: list lengths don't match"
 
+pickyZip :: [a] -> [b] -> [(a,b)]
+pickyZip = pickyZipWith (,)
+
 -- Collects duplicates, counting how many
 -- collectDups ['a', 'b', 'c', 'b', 'c', 'b'] = [('a', 1), ('b', 3), ('c', 2)]
 collectDups :: Ord a => [a] -> [(a, Int)]


### PR DESCRIPTION
This was quite a big edit. There were a number of places where it definitely improved, but a lot of places where `[]` got changed to `[] []`, which is not great.

Closes #81.