### PR TITLE
Eliminate repetitions in FGG

### DIFF
--- a/src/Compile/Compile.hs
+++ b/src/Compile/Compile.hs
@@ -389,4 +389,4 @@ compileFile ps =
       Progs _ end = ps
       RuleM rs xs nts fs = progs2fgg g ps
   in
-      return (rulesToFGG (domainValues g) (ElNonterminal end) (reverse rs) nts fs)
+      return (rulesToFGG (domainValues g) (ElNonterminal end) [typeof end] (reverse rs))

--- a/src/Compile/Compile.hs
+++ b/src/Compile/Compile.hs
@@ -1,4 +1,4 @@
-module Compile.Compile where
+module Compile.Compile (compileFile, domainSize) where
 import Data.List
 import qualified Data.Map as Map
 import Compile.RuleM

--- a/src/Compile/RuleM.hs
+++ b/src/Compile/RuleM.hs
@@ -147,7 +147,7 @@ getWeights size = h where
   h (FaAddProd tps k) = Just (getSumWeights (size <$> tps) k)
   h (FaMulProd tps) = Just (getProdWeights (size <$> tps))
   h (FaCtor cs k) = Just (getCtorWeights size (cs !! k) cs)
-  h (FaExtern _) = Nothing
+  h (FaExtern _ _) = Nothing
 
 {- rulesToFGG dom start rs nts facs
 

--- a/src/Compile/RuleM.hs
+++ b/src/Compile/RuleM.hs
@@ -8,8 +8,6 @@ import Util.FGG
 import Util.Helpers
 import Util.Tensor
 
-type External = (NodeName, NodeLabel)
-
 type RuleM = Writer (Map EdgeLabel [HGF])
 
 {- addRuleBlock lhs rhss

--- a/src/Compile/RuleM.hs
+++ b/src/Compile/RuleM.hs
@@ -3,7 +3,6 @@
 module Compile.RuleM where
 import qualified Data.Map as Map
 import Control.Monad.Writer.Lazy
-import Data.List
 import Struct.Lib
 import Util.FGG
 import Util.Helpers
@@ -29,19 +28,6 @@ runRuleM :: RuleM () -> [Rule]
 runRuleM rm =
   let ((), rs) = runWriter rm in
     concat [[Rule lhs rhs | rhs <- rhss] | (lhs, rhss) <- Map.toList rs]
-
-infixl 1 +>=, +>=*
--- Like (>>=) but for RuleM
--- Second arg receives as input the external nodes from the first arg  
-(+>=) :: RuleM [External] -> ([External] -> RuleM [External]) -> RuleM [External]
-rm +>= g =
-  rm >>= \ xs ->
-  g xs >>= \ xs' ->
-  return (unionBy (\ (a, _) (a', _) -> a == a') xs xs')
-
--- Sequence together RuleM [External], collecting each's externals
-(+>=*) :: [RuleM [External]] -> ([[External]] -> RuleM [External]) -> RuleM [External]
-rs +>=* rf = sequence rs >>= rf
 
 {--- Functions for computing Weights for terminal-labeled Edges ---}
 
@@ -128,7 +114,7 @@ getWeights size = h where
 
    - dom: function that gives the possible Values belonging to d
    - start: start nonterminal
-   - rs: list of rules with repetition counts
+   - rs: list of rules
    - nts: list of nonterminal EdgeLabels and their "types"
    - facs: list of factors -}
              

--- a/src/Compile/RuleM.hs
+++ b/src/Compile/RuleM.hs
@@ -25,7 +25,7 @@ addRuleBlock lhs rhss = tell (Map.singleton lhs rhss)
 runRuleM :: RuleM () -> [Rule]
 runRuleM rm =
   let ((), rs) = runWriter rm in
-    concat [[Rule lhs rhs | rhs <- rhss] | (lhs, rhss) <- Map.toList rs]
+    [Rule lhs rhs | (lhs, rhss) <- Map.toList rs, rhs <- rhss]
 
 {--- Functions for computing Weights for terminal-labeled Edges ---}
 

--- a/src/Compile/RuleM.hs
+++ b/src/Compile/RuleM.hs
@@ -180,10 +180,10 @@ getEqWeights size ntms =
              
 rulesToFGG :: (NodeLabel -> Domain) -> EdgeLabel -> [(Int, Rule)] -> [(EdgeLabel, [NodeLabel])] -> [Terminal] -> FGG
 rulesToFGG dom start rs nts facs =
-  FGG ds fs nts' start rs'
+  FGG ds fs nts' start rs''
   where
     rs' = nubBy (\ (_, r1) (_, r2) -> r1 == r2) rs
-    rs'' = [r | (_, r) <- rs']
+    rs'' = concat [replicate reps r | (reps, r) <- rs']
 
     nls = concat (map (\ (Rule lhs (HGF ns es xs)) -> snds ns) rs'') ++
           concat (snds nts)

--- a/src/Compile/RuleM.hs
+++ b/src/Compile/RuleM.hs
@@ -1,6 +1,6 @@
 {- Code for generating FGG rules, and the RuleM monad. -}
 
-module Compile.RuleM where
+module Compile.RuleM (RuleM, addRuleBlock, runRuleM, getWeights, rulesToFGG) where
 import qualified Data.Map as Map
 import Control.Monad.Writer.Lazy
 import Struct.Lib

--- a/src/Struct/Exprs.hs
+++ b/src/Struct/Exprs.hs
@@ -79,14 +79,14 @@ data UsTm =
   | UsEqs [UsTm]                        -- tm1 == tm2 == ...
   deriving (Eq, Ord)
 
-data GlobalVar = CtorVar | DefVar
-  deriving (Eq, Ord)
+data Global = GlFun | GlExtern | GlCtor
+  deriving (Eq, Ord, Show)
 
 -- With the exception of TmLam, the Type at the end of a constructor
 -- below is the type of that expression as a whole
 data Term =
     TmVarL Var Type                               -- Local var
-  | TmVarG GlobalVar Var [Tag] [Type] [Arg] Type -- Global var app: x [tg1] ... [ti1] ... arg1 ...
+  | TmVarG Global Var [Tag] [Type] [Arg] Type     -- Global var app: x [tg1] ... [ti1] ... arg1 ...
   | TmLam Var Type Term Type                      -- \ x : tp1. tm : tp2
   | TmApp Term Term Type {- -> -} Type            -- (tm1 : (tp1 -> tp2)) (tm2 : tp1) : tp2
   | TmLet Var Term Type Term Type                 -- let x : tp1 = tm1 in tp2 : tp2

--- a/src/Struct/Helpers.hs
+++ b/src/Struct/Helpers.hs
@@ -170,8 +170,8 @@ tpBoolName = Var "Bool"
 tmTrueName = Var "True"
 tmFalseName = Var "False"
 tpBool = TpData tpBoolName [] []
-tmTrue = TmVarG CtorVar tmTrueName [] [] [] tpBool
-tmFalse = TmVarG CtorVar tmFalseName [] [] [] tpBool
+tmTrue = TmVarG GlCtor tmTrueName [] [] [] tpBool
+tmFalse = TmVarG GlCtor tmFalseName [] [] [] tpBool
 
 builtins :: [UsProg]
 builtins = [

--- a/src/Transform/AffLin.hs
+++ b/src/Transform/AffLin.hs
@@ -84,7 +84,7 @@ discard' x (TpProd Multiplicative tps) rtm =
 discard' x xtp@(TpData y [] []) rtm =
   ask >>= \ g ->
     -- let () = discard x in rtm
-    return (TmElimMultiplicative (TmVarG DefVar (discardName y) [] [] [(x, xtp)] tpUnit) [] rtm (typeof rtm))
+    return (TmElimMultiplicative (TmVarG GlFun (discardName y) [] [] [(x, xtp)] tpUnit) [] rtm (typeof rtm))
 discard' _ tp _ = error ("Trying to discard a " ++ show tp)
 
 -- If x : tp contains an affinely-used function, we sometimes need to discard

--- a/src/Transform/Argify.hs
+++ b/src/Transform/Argify.hs
@@ -60,7 +60,7 @@ argifyFile (Progs ps tm) = Progs (map argifyProg ps) (argifyTerm tm) where
 
   -- Argify an application of a global definition (TmVarG g x [] [] [] _)
   -- to zero or more arguments (as).
-  argifyAppG :: GlobalVar -> Var -> [Arg] -> Term
+  argifyAppG :: Global -> Var -> [Arg] -> Term
   argifyAppG g x as =
     -- as = the provided arguments
     -- tps = the argument types of x

--- a/src/Transform/Optimize.hs
+++ b/src/Transform/Optimize.hs
@@ -163,7 +163,7 @@ safe2sub g x xtm tm =
     -- Returns if there are no global def vars or ambs/fails/uniforms
     noDefsSamps :: Term -> Bool
     noDefsSamps (TmVarL x tp) = True
-    noDefsSamps (TmVarG g x _ _ as tp) = g == CtorVar && all (noDefsSamps . fst) as
+    noDefsSamps (TmVarG g x _ _ as tp) = g == GlCtor && all (noDefsSamps . fst) as
     noDefsSamps (TmLam x tp tm tp') = noDefsSamps tm
     noDefsSamps (TmApp tm1 tm2 tp2 tp) = noDefsSamps tm1 && noDefsSamps tm2
     noDefsSamps (TmLet x xtm xtp tm tp) = noDefsSamps xtm && noDefsSamps tm
@@ -206,7 +206,7 @@ optimizeTerm g (TmApp tm1 tm2 tp2 tp) =
 optimizeTerm g (TmCase tm y cs tp) =
   let tm' = optimizeTerm g tm in
     case splitLets tm' of
-      (ds, TmVarG CtorVar x tgs tis as _) ->
+      (ds, TmVarG GlCtor x tgs tis as _) ->
         let [Case _ cps ctm] = filter (\ (Case x' _ _) -> x == x') cs
             p_a_ds = zipWith (\ (tm, _) (x', tp) -> (x', tm, tp)) as cps in
           optimizeTerm g (joinLets (ds ++ p_a_ds) ctm)

--- a/src/Util/FGG.hs
+++ b/src/Util/FGG.hs
@@ -3,7 +3,11 @@
    FGGs, see: David Chiang and Darcey Riley. Factor graph grammars. In
    Proc. NeurIPS, 6648–6658. 2020. -}
 
-module Util.FGG where
+module Util.FGG (Node, NodeName(..), NodeLabel,
+                  Domain, Value(..),
+                  Edge(..), EdgeLabel(..),
+                  Factor(..), Weights, Weight,
+                  HGF(..), Rule(..), FGG(..), showFGG) where
 import qualified Data.Map as Map
 import Struct.Lib
 import Util.Helpers
@@ -152,10 +156,3 @@ fgg_to_json (FGG ds fs nts s rs) =
 
 showFGG :: FGG -> String
 showFGG = pprint_json . fgg_to_json
-
-{- emptyFGG s
-
-   An FGG with start nonterminal s and no rules. -}
-emptyFGG :: EdgeLabel -> FGG
-emptyFGG s = FGG Map.empty Map.empty Map.empty s []
-

--- a/src/Util/FGG.hs
+++ b/src/Util/FGG.hs
@@ -5,7 +5,6 @@
 
 module Util.FGG where
 import qualified Data.Map as Map
-import Data.List
 import Struct.Lib
 import Util.Helpers
 import Util.Tensor
@@ -82,7 +81,7 @@ data FGG = FGG {
   factors :: Map EdgeLabel ([NodeLabel], Maybe Weights), -- edge label to att node labels, weights
   nonterminals :: Map EdgeLabel [NodeLabel],             -- nt name to attachment node labels
   start :: EdgeLabel,                                    -- start nt
-  rules :: [(Int, Rule)]                                 -- [(reps, rule)]: reps keeps track of duplicate rules that should not be deduplicated
+  rules :: [Rule]                                        -- rules
 }
 
 -- Creates a JSON object from a weights tensor
@@ -106,10 +105,10 @@ fgg_to_json (FGG ds fs nts s rs) =
            ("type", JSarray [JSstring (show nl) | nl <- d])
          ])),
        ("start", JSstring (show s)),
-       ("rules", JSarray $ concat $ flip map (nubBy (\ (_, r1) (_, r2) -> r1 == r2) rs) $
-          \ (reps, Rule lhs (HGF ns es xs)) ->
+       ("rules", JSarray $ flip map rs $
+          \ (Rule lhs (HGF ns es xs)) ->
             let m = Map.fromList (zip (fsts ns) [0..]) in
-            replicate reps $ JSobject [
+            JSobject [
              ("lhs", JSstring (show lhs)),
              ("rhs", JSobject [
                  ("nodes", JSarray [JSobject [("label", JSstring (show d)), ("id", JSstring (show n))] | (n, d) <- ns]),

--- a/src/Util/FGG.hs
+++ b/src/Util/FGG.hs
@@ -67,7 +67,7 @@ data Factor =
   | FaAddProd [Type] Int                -- matrix projecting tp1+...+tpn to tpk
   | FaMulProd [Type]                    -- tensor mapping (tp1,...,tpn) to tp1,...,tpn
   | FaCtor [Ctor] Int                   -- k'th constructor in cs
-  | FaExtern                            -- weights supplied externally
+  | FaExtern Type                       -- weights supplied externally
   deriving (Show, Eq, Ord)
 
 data Edge = Edge { edge_atts :: [(NodeName, NodeLabel)], edge_label :: EdgeLabel }

--- a/src/Util/FGG.hs
+++ b/src/Util/FGG.hs
@@ -9,6 +9,7 @@ import Struct.Lib
 import Util.Helpers
 import Util.Tensor
 import Util.JSON
+import Data.List (intercalate)
 
 type Domain = [Value]
 newtype Value = Value String
@@ -67,8 +68,16 @@ data Factor =
   | FaAddProd [Type] Int                -- matrix projecting tp1+...+tpn to tpk
   | FaMulProd [Type]                    -- tensor mapping (tp1,...,tpn) to tp1,...,tpn
   | FaCtor [Ctor] Int                   -- k'th constructor in cs
-  | FaExtern Type                       -- weights supplied externally
-  deriving (Show, Eq, Ord)
+  | FaExtern Var Type                   -- weights supplied externally
+  deriving (Eq, Ord)
+instance Show Factor where
+  show (FaScalar w) = show w
+  show (FaIdentity tp) = "Identity[" ++ show tp ++ "]"
+  show (FaEqual tp n) = "Equal[" ++ show tp ++ "^" ++ show n ++ "]"
+  show (FaAddProd tps k) = "AddProd[" ++ intercalate "," (show <$> tps) ++ ";" ++ show k ++ "]"
+  show (FaMulProd tps) = "MulProd[" ++ intercalate "," (show <$> tps) ++ "]"
+  show (FaCtor cs k) = show (cs !! k)
+  show (FaExtern x _) = show x
 
 data Edge = Edge { edge_atts :: [(NodeName, NodeLabel)], edge_label :: EdgeLabel }
   deriving Eq

--- a/src/Util/FGG.hs
+++ b/src/Util/FGG.hs
@@ -79,10 +79,11 @@ instance Show Factor where
   show (FaCtor cs k) = show (cs !! k)
   show (FaExtern x _) = show x
 
-data Edge = Edge { edge_atts :: [(NodeName, NodeLabel)], edge_label :: EdgeLabel }
+type Node = (NodeName, NodeLabel)
+data Edge = Edge { edge_atts :: [Node], edge_label :: EdgeLabel }
   deriving Eq
 -- Hypergraph fragment (= hypergraph with external nodes)
-data HGF = HGF { hgf_nodes :: [(NodeName, NodeLabel)], hgf_edges :: [Edge], hgf_exts :: [(NodeName, NodeLabel)] }
+data HGF = HGF { hgf_nodes :: [Node], hgf_edges :: [Edge], hgf_exts :: [Node] }
   deriving Eq
 data Rule = Rule EdgeLabel HGF
   deriving Eq

--- a/src/Util/FGG.hs
+++ b/src/Util/FGG.hs
@@ -67,6 +67,7 @@ data Factor =
   | FaAddProd [Type] Int                -- matrix projecting tp1+...+tpn to tpk
   | FaMulProd [Type]                    -- tensor mapping (tp1,...,tpn) to tp1,...,tpn
   | FaCtor [Ctor] Int                   -- k'th constructor in cs
+  | FaExtern                            -- weights supplied externally
   deriving (Show, Eq, Ord)
 
 data Edge = Edge { edge_atts :: [(NodeName, NodeLabel)], edge_label :: EdgeLabel }

--- a/src/Util/Helpers.hs
+++ b/src/Util/Helpers.hs
@@ -37,10 +37,6 @@ kronwith f as bs = [f a b | (a, b) <- concat (kronecker as bs)]
 kronall :: [[a]] -> [[a]]
 kronall = foldr (\ vs ws -> [(v : xs) | v <- vs, xs <- ws ]) [[]]
 
--- kronall, but keeps track of the position (row, col) each element came from
-kronpos :: [[a]] -> [[(Int, Int, a)]]
-kronpos as = kronall [[(i, length as', a) | (i, a) <- enumerate as'] | as' <- as]
-
 -- [a, b, c, ...] -> [(0, a), (1, b), (2, c), ...]
 enumerate :: [a] -> [(Int, a)]
 enumerate = zip [0..]
@@ -89,12 +85,6 @@ pickyZipWith f = go where
 
 pickyZip :: [a] -> [b] -> [(a,b)]
 pickyZip = pickyZipWith (,)
-
--- Collects duplicates, counting how many
--- collectDups ['a', 'b', 'c', 'b', 'c', 'b'] = [('a', 1), ('b', 3), ('c', 2)]
-collectDups :: Ord a => [a] -> [(a, Int)]
-collectDups =
-  Map.toList . foldr (Map.alter $ Just . maybe 1 succ) Map.empty
 
 listDifference :: Ord a => [a] -> [a] -> [a]
 listDifference as1 as2 = Set.toList (Set.difference (Set.fromList as1) (Set.fromList as2))

--- a/src/Util/SumProduct.hs
+++ b/src/Util/SumProduct.hs
@@ -15,7 +15,7 @@ multiTensorDistance mt1 mt2 =
     foldr max 0.0 (fmap (foldr max 0.0 . tensorFlatten) diff)
 
 nonterminalGraph :: FGG -> Map EdgeLabel (Set EdgeLabel)
-nonterminalGraph fgg = foldr (\ (Rule lhs rhs) g -> Map.insertWith Set.union lhs (nts rhs) g) (fmap (const mempty) (nonterminals fgg)) (repRules fgg)
+nonterminalGraph fgg = foldr (\ (Rule lhs rhs) g -> Map.insertWith Set.union lhs (nts rhs) g) (fmap (const mempty) (nonterminals fgg)) (rules fgg)
   where nts rhs = Set.fromList [edge_label e | e <- hgf_edges rhs, edge_label e `Map.member` nonterminals fgg]
 
 sumProduct :: FGG -> Tensor Weight
@@ -44,9 +44,6 @@ zero fgg nts =
 nonterminalShape :: FGG -> EdgeLabel -> [Int]
 nonterminalShape fgg x = [length ((domains fgg) Map.! nl) | nl <- (nonterminals fgg) Map.! x]
 
-repRules :: FGG -> [Rule]
-repRules fgg = concat [ replicate c r | (c, r) <- rules fgg ]
-  
 step :: FGG -> [EdgeLabel] -> MultiTensor -> MultiTensor
 step fgg nts z =
   Map.union (Map.fromList [ (x, stepNonterminal x) | x <- nts ]) z
@@ -54,7 +51,7 @@ step fgg nts z =
 
     stepNonterminal :: EdgeLabel -> Tensor Weight
     stepNonterminal x =
-      foldr tensorAdd (zeros (nonterminalShape fgg x)) [stepRHS rhs | Rule lhs rhs <- repRules fgg, lhs == x]
+      foldr tensorAdd (zeros (nonterminalShape fgg x)) [stepRHS rhs | Rule lhs rhs <- rules fgg, lhs == x]
 
     stepRHS :: HGF -> Tensor Weight
     stepRHS (HGF nodes edges exts) = h [] nodes'


### PR DESCRIPTION
Make RuleM accumulate "blocks" of rules (all rules with a given lhs) instead of individual rules. This lets it drop duplicate blocks but not duplicate rules within a block, so that it's not necessary to keep track of repetition counts. That might be exchanging one wrinkle for another, but this way seems more conceptually correct to me.

In addition, RuleM really is a Monad now; it's just `Writer [Rule]`. A lot of the code associated with RuleM can therefore be deleted.

To keep externs to compile correctly, we need to distinguish between TmVarG when the global variable is a define versus an extern.
