### PR TITLE
Restore substTypes and substTags

### DIFF
--- a/src/Scope/Subst.hs
+++ b/src/Scope/Subst.hs
@@ -4,6 +4,7 @@
 module Scope.Subst (SubT(..), Subst, compose,
                     Substitutable,
                     substM, subst, substWithCtxt, alphaRename,
+                    substTags,
                     FreeVars, freeVars) where
 import qualified Data.Map as Map
 import Control.Monad.RWS.Lazy
@@ -119,9 +120,7 @@ Subst s is a Map from variables x to three kinds of substitutions:
 - x := SubTm tm replaces:
   * free occurrences of local variables x (TmVarL x but not UsVar x)
 - x := SubTp tp replaces:
-  * free occurrences of type variables x (TpVar x)
-  * if x is a datatype name (TpData x) and tp has no type parameters,
-    x is changed to tp's name, and tp's tags are prepended. -}
+  * free occurrences of type variables x (TpVar x) -}
   
 subst :: Substitutable a => Subst -> a -> a
 subst s a = runSubst s (substM a)
@@ -153,10 +152,7 @@ instance Substitutable Type where
     substVar y
       (\ y' -> TpData y' tgs' as')
       (const (TpData y tgs' as'))
-      -- Allow y := y' tg1 ....
-      -- This is used in TypeInf.Solve in inferData to add tags to a datatype.
-      (\ tp' -> case tp' of TpData y' tgs'' [] -> TpData y' (tgs'' ++ tgs') as'
-                            _ -> error ("kind error (" ++ show y ++ " := " ++ show tp' ++ ")"))
+      (const (TpData y tgs' as'))
       (const (TpData y tgs' as'))
       (TpData y tgs' as')
   substM (TpProd am tps) = pure (TpProd am) <*> substM tps
@@ -383,3 +379,29 @@ instance Substitutable SProgs where
     pure SProgs <*> substM ps <*> substM tm
   freeVars (SProgs ps tm) =
     Map.union (freeVars ps) (freeVars tm)
+
+--- The following functions don't use Subst.
+
+{- substTags ytgs tp
+
+   Adds tags to type vars.
+
+   - ytgs: Map from Vars (which are datatype names) to lists of Vars
+     (which are tag names). -}
+
+substTags :: Map Var [Var] -> Type -> Type
+substTags ytgs (TpVar y) = TpVar y
+substTags ytgs (TpData y [] as) =
+  let as' = map (substTags ytgs) as in
+    TpData y (maybe [] (TgVar <$>) (ytgs Map.!? y)) as'
+substTags ytgs (TpData y tgs as) =
+    if y `Map.member` ytgs then
+      error ("can't add tags to a datatype that already has tags")
+    else
+      let as' = map (substTags ytgs) as in
+        TpData y tgs as'
+substTags ytgs (TpArr tp1 tp2) =
+  TpArr (substTags ytgs tp1) (substTags ytgs tp2)
+substTags ytgs (TpProd am tps) =
+  TpProd am (map (substTags ytgs) tps)
+substTags ytgs NoTp = NoTp

--- a/src/Transform/DR.hs
+++ b/src/Transform/DR.hs
@@ -5,7 +5,7 @@ import Data.List
 import Struct.Lib
 import Util.Helpers
 import Scope.Free (getRecursiveTypeNames)
-import Scope.Subst (Substitutable, SubT(SubVar), subst, FreeVars, freeVars)
+import Scope.Subst (Substitutable, FreeVars, freeVars, substDatatype)
 import Scope.Ctxt (Ctxt, ctxtDefProgs, ctxtDeclArgs, ctxtLookupTerm, ctxtLookupType)
 import Scope.Fresh (newVar)
 import Scope.Name
@@ -216,7 +216,7 @@ data DeRe = Defun | Refun
 
 -- Substitute from a datatype name to its Unfold/Fold datatype's name
 derefunSubst :: DeRe -> Var -> Type -> Type
-derefunSubst dr rtp = subst (Map.fromList [(rtp, SubVar (if dr == Defun then foldTypeName rtp else unfoldTypeName rtp))])
+derefunSubst dr rtp = substDatatype rtp (if dr == Defun then foldTypeName rtp else unfoldTypeName rtp)
 
 defunTerm = derefunTerm Defun
 refunTerm = derefunTerm Refun

--- a/src/Transform/Optimize.hs
+++ b/src/Transform/Optimize.hs
@@ -3,7 +3,7 @@ import qualified Data.Map as Map
 import Struct.Lib
 import Util.Helpers
 import Scope.Name (localName)
-import Scope.Free (isLin', robust)
+import Scope.Free (isLin, robust)
 import Scope.Subst (SubT(SubTm), substWithCtxt, FreeVars, freeVars)
 import Scope.Fresh (newVar)
 import Scope.Ctxt (Ctxt, ctxtDeclArgs, ctxtDefLocal, ctxtDefProgs)
@@ -153,7 +153,7 @@ peelLams g ps tm =
 -- no free vars that aren't also free in the other term, and no effects
 safe2sub :: Ctxt -> Var -> Term -> Term -> Bool
 safe2sub g x xtm tm =
-  isLin' x tm || (noDefsSamps xtm && fvsOkay (freeVars xtm))
+  isLin x tm || (noDefsSamps xtm && fvsOkay (freeVars xtm))
   where
     fvsOkay :: FreeVars -> Bool
     -- TODO: don't need to check isInfiniteType g tp, once we can copy terms with recursive datatypes

--- a/src/TypeInf/Solve.hs
+++ b/src/TypeInf/Solve.hs
@@ -7,9 +7,10 @@ import TypeInf.Check
 import Util.Helpers
 import Util.Graph (scc)
 import Struct.Lib
-import Scope.Subst (SubT(SubTm,SubTp,SubTg), Subst, compose, subst, freeVars)
+import Scope.Subst (SubT(SubTm,SubTp,SubTg), Subst, compose, subst, freeVars, substTags)
 import Scope.Free (robust)
 import Scope.Ctxt (Ctxt, emptyCtxt)
+import Debug.Trace
 
 bindTp :: Var -> Type -> Either TypeError Subst
 bindTp x tp
@@ -364,9 +365,9 @@ inferData dsccs cont = foldr h cont dsccs
       -- by substituting y := y tgs.
       
       let tgs = Map.keys (Map.filter id vs)
-          s = Map.fromList [(y, SubTp (TpData y (TgVar <$> tgs) [])) | (y, ps, cs) <- dscc']
-      in
-        return [(y, tgs, ps, mapCtors (subst s) cs) | (y, ps, cs) <- dscc']
+          s = Map.fromList [(y, tgs) | (y, ps, cs) <- dscc']
+      in traceShow s $
+        return [(y, tgs, ps, mapCtors (substTags s) cs) | (y, ps, cs) <- dscc']
 
 
 -- Checks an extern declaration


### PR DESCRIPTION
A while ago I removed `substTags` and `substType`, thinking to streamline things by letting `subst` do everything. But it seems to complicate #81 if `subst` is able to substitute so many different kinds of variables. This puts the two functions back. However, note

- `substType` never attempted to check for variable capture, so in a way this is a step backwards. Hopefully, whatever fixes #74 will fix this.
- `freeVars` still considers datatype names (`TpData`) to be free variables, so `subst` is also still able to substitute them (but the latter is never used).