### PR TITLE
Fixes #109 by tracking which define type parameters are robust

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -9,7 +9,7 @@ my_errs=()
 
 for file in \
     examples/{bool,dyck,extinction,fsm,list,nat,parser,pattern1,pattern2,pda,penney,reverse,stairs,tree,von_neumann}.ppl \
-    tests/good/{amb,fail,sample,products,type_parameter_{nonrecursive,unused,different,swap},{zero,one,discard}_add_prod,datatype_containing_type_application,partial_application{,_recursive},{amb,factor}_lambda_{0,1,2},function_polymorphism,infinite_fails,case_lambda,discard_prods}.ppl
+    tests/good/{amb,fail,sample,products,type_parameter_{nonrecursive,unused,different,swap},{zero,one,discard}_add_prod,datatype_containing_type_application,partial_application{,_recursive},{amb,factor}_lambda_{0,1,2},function_polymorphism,infinite_fails,case_lambda,discard_prods,forall_positive_unused_type_parameter}.ppl
 do
     printf '%-40s' "Compiling ${file}... "
     my_err=$(./perplc $file -o /dev/null 2>&1 > /dev/null)

--- a/src/Scope/Ctxt.hs
+++ b/src/Scope/Ctxt.hs
@@ -12,7 +12,7 @@ data CtxtDef =
 
 data CtTerm =
     CtLocal Type
-  | CtDefine [Var] [Var] Type -- tags, type params, type
+  | CtDefine [Var] [Forall] Type -- tags, type params, type
   | CtExtern Type
   | CtCtor [Var] [Var] Type   -- tags, type params, type
   deriving Show
@@ -37,7 +37,7 @@ ctxtAddArgs :: Ctxt -> [Param] -> Ctxt
 ctxtAddArgs = foldl $ uncurry . ctxtAddLocal
 
 -- Add a global term to the context
-ctxtAddDefine :: Ctxt -> Var -> [Var] -> [Var] -> Type -> Ctxt
+ctxtAddDefine :: Ctxt -> Var -> [Var] -> [Forall] -> Type -> Ctxt
 ctxtAddDefine g x tgs ps tp = Map.insert x (CtTerm (CtDefine tgs ps tp)) g
 
 ctxtAddExtern :: Ctxt -> Var -> Type -> Ctxt

--- a/src/Scope/Subst.hs
+++ b/src/Scope/Subst.hs
@@ -353,9 +353,12 @@ instance Substitutable SProg where
     bind x x okay >>
     freshens tgs >>= \ tgs' ->
     binds tgs tgs'
-      (freshens tpms >>= \ tpms' ->
-       binds tpms tpms'
-         (pure (SProgDefine x tgs' tpms') <*> substM tp <*> substM tm))
+      (let (tpmxs, tpmrs) = unzip [(x, r) | Forall x r <- tpms]
+           tpms' = [Forall x r | (x, r) <- zip tpmxs tpmrs]
+       in
+         freshens tpmxs >>= \ tpmxs' ->
+          binds tpmxs tpmxs'
+            (pure (SProgDefine x tgs' tpms') <*> substM tp <*> substM tm))
   substM (SProgExtern x tp) =
     bind x x okay >>
     pure (SProgExtern x) <*> substM tp

--- a/src/Scope/Subst.hs
+++ b/src/Scope/Subst.hs
@@ -343,10 +343,9 @@ instance Substitutable SProg where
     bind x x okay >>
     freshens tgs >>= \ tgs' ->
     binds tgs tgs'
-      (let (tpmxs, tpmrs) = unzip [(x, r) | Forall x r <- tpms]
-           tpms' = [Forall x r | (x, r) <- zip tpmxs tpmrs]
-       in
+      (let (tpmxs, tpmrs) = unzip [(x, r) | Forall x r <- tpms] in
          freshens tpmxs >>= \ tpmxs' ->
+         let tpms' = [Forall x r | (x, r) <- zip tpmxs' tpmrs] in
           binds tpmxs tpmxs'
             (pure (SProgDefine x tgs' tpms') <*> substM tp <*> substM tm))
   substM (SProgExtern x tp) =

--- a/src/Struct/Exprs.hs
+++ b/src/Struct/Exprs.hs
@@ -19,7 +19,9 @@ data UsProg =
   | UsProgData Var [Var] [Ctor]         -- lhs, type params, constructors
   deriving (Eq, Ord)
 
-data Forall = Forall Var Bool -- name, is robust
+data Forall = Forall Var Bound
+  deriving (Eq, Ord)
+data Bound = BoundRobust | BoundNone
   deriving (Eq, Ord)
 
 -- Scheme-ified definition

--- a/src/Struct/Exprs.hs
+++ b/src/Struct/Exprs.hs
@@ -19,9 +19,12 @@ data UsProg =
   | UsProgData Var [Var] [Ctor]         -- lhs, type params, constructors
   deriving (Eq, Ord)
 
+data Forall = Forall Var Bool -- name, is robust
+  deriving (Eq, Ord)
+
 -- Scheme-ified definition
 data SProg =
-    SProgDefine Var [Var] [Var] Term Type  -- lhs, tags, type params, rhs, type
+    SProgDefine Var [Var] [Forall] Term Type  -- lhs, tags, type params, rhs, type
   | SProgExtern Var Type                -- lhs, type
   | SProgData Var [Var] [Var] [Ctor]    -- lhs, tags, type params, constructors
   deriving (Eq, Ord)

--- a/src/Struct/Show.hs
+++ b/src/Struct/Show.hs
@@ -102,8 +102,12 @@ instance Show UsProg where
 instance Show UsProgs where
   show (UsProgs ps end) = intercalate "\n\n" ([show p | p <- ps] ++ [show end]) ++ "\n"
 
+instance Show Forall where
+  show (Forall x r) =
+    "∀" ++ (if r then "1" else "") ++ " " ++ show x ++ "."
+
 instance Show SProg where
-  show (SProgDefine x tgs ps tm tp) = "define " ++ show x ++ " : " ++ intercalate " " (["∀ " ++ show a ++ "." | a <- tgs ++ ps] ++ [show tp]) ++ " = " ++ show tm ++ ";"
+  show (SProgDefine x tgs ps tm tp) = "define " ++ show x ++ " : " ++ intercalate " " (["∀ " ++ show a ++ "." | a <- tgs] ++ map show ps ++ [show tp]) ++ " = " ++ show tm ++ ";"
   show (SProgExtern x tp) = "extern " ++ show x ++ " : " ++ show tp ++ ";"
   show (SProgData y tgs ps cs) = "data " ++ intercalate " " (show <$> y : tgs ++ ps) ++ " = " ++ intercalate " | " [show c | c <- cs] ++ ";"
 

--- a/src/Struct/Show.hs
+++ b/src/Struct/Show.hs
@@ -103,8 +103,8 @@ instance Show UsProgs where
   show (UsProgs ps end) = intercalate "\n\n" ([show p | p <- ps] ++ [show end]) ++ "\n"
 
 instance Show Forall where
-  show (Forall x r) =
-    "∀" ++ (if r then "1" else "") ++ " " ++ show x ++ "."
+  show (Forall x bd) =
+    "∀" ++ (case bd of {BoundRobust -> "+"; BoundNone -> ""}) ++ " " ++ show x ++ "."
 
 instance Show SProg where
   show (SProgDefine x tgs ps tm tp) = "define " ++ show x ++ " : " ++ intercalate " " (["∀ " ++ show a ++ "." | a <- tgs] ++ map show ps ++ [show tp]) ++ " = " ++ show tm ++ ";"

--- a/src/Transform/Monomorphize.hs
+++ b/src/Transform/Monomorphize.hs
@@ -129,7 +129,7 @@ makeDefMap = semimap . mconcat . map h where
 -- Store the tag and type vars each definition is polymorphic over
 makeTypeParams :: [SProg] -> TypeParams
 makeTypeParams = mconcat . map h where
-  h (SProgDefine x tgs ys tm tp) = Map.singleton x (tgs, ys)
+  h (SProgDefine x tgs ys tm tp) = Map.singleton x (tgs, [y | Forall y r <- ys])
   h (SProgExtern x tp) = Map.singleton x ([], [])
   h (SProgData y tgs ps cs) = Map.fromList ((y, (tgs, ps)) : map (\ (Ctor x tps) -> (x, (tgs, ps))) cs)
 
@@ -165,10 +165,11 @@ makeInstantiations xis (SProgDefine x [] [] tm tp) =
   else
     [ProgDefine x [] (renameCalls xis tm) (renameCallsTp xis tp)]
 makeInstantiations xis (SProgDefine x tgs ps tm tp) =
-  let tiss = Map.toList (xis Map.! x) in
+  let tiss = Map.toList (xis Map.! x)
+      ps' = [y | Forall y r <- ps] in
     map (\ ((tgs', tis), i) ->
            let s = Map.fromList (pickyZip tgs (SubTg <$> tgs') ++
-                                 pickyZip ps  (SubTp <$> tis )) in
+                                 pickyZip ps' (SubTp <$> tis )) in
              ProgDefine
                (instName x i) -- new name for this particular instantiation
                [] -- args are [], for now (see Transform.Argify)

--- a/src/TypeInf/Check.hs
+++ b/src/TypeInf/Check.hs
@@ -285,12 +285,14 @@ infer' (UsVar x) =
     CtExtern tp -> h GlExtern [] [] tp
     CtCtor tgs tis tp -> h GlCtor tgs [Forall y False | y <- tis] tp
   where
+    -- Any ∀-quantified type variables should be instantiated to fresh type variables
     h gv tgs tis tp =
      let ytis = [y | Forall y r <- tis] in
       -- pick new tags
       mapM (const freshTag) tgs >>= \ tgs' ->
       -- pick new type vars
       mapM (const freshTp) ytis >>= \ tis' ->
+      -- ...that inherit any robustness constraints
       mapM (\ (Forall y r, ytp) -> constrainIf r (Robust ytp)) (zip tis tis') >>
       -- substitute old tags/type vars for new ones
        let tp' = subst (Map.fromList (pickyZip tgs (SubTg <$> tgs') ++

--- a/src/TypeInf/Check.hs
+++ b/src/TypeInf/Check.hs
@@ -283,7 +283,7 @@ infer' (UsVar x) =
     CtLocal tp -> return (TmVarL x tp)
     CtDefine tgs tis tp -> h GlDefine tgs tis tp
     CtExtern tp -> h GlExtern [] [] tp
-    CtCtor tgs tis tp -> h GlCtor tgs [Forall y False | y <- tis] tp
+    CtCtor tgs tis tp -> h GlCtor tgs [Forall y BoundNone | y <- tis] tp
   where
     -- Any ∀-quantified type variables should be instantiated to fresh type variables
     h gv tgs tis tp =
@@ -293,7 +293,7 @@ infer' (UsVar x) =
       -- pick new type vars
       mapM (const freshTp) ytis >>= \ tis' ->
       -- ...that inherit any robustness constraints
-      mapM (\ (Forall y r, ytp) -> constrainIf r (Robust ytp)) (zip tis tis') >>
+      mapM (\ (Forall y bd, ytp) -> constrainIf (bd == BoundRobust) (Robust ytp)) (zip tis tis') >>
       -- substitute old tags/type vars for new ones
        let tp' = subst (Map.fromList (pickyZip tgs (SubTg <$> tgs') ++
                                       pickyZip ytis (SubTp <$> tis'))) tp in

--- a/src/TypeInf/Check.hs
+++ b/src/TypeInf/Check.hs
@@ -155,7 +155,7 @@ guardExternRec tp =
   guardM (not (isInfiniteType env tp)) ExternRecData
 
 -- Defines a global function
-defGlobal :: Var -> [Var] -> [Var] -> Type -> CheckM a -> CheckM a
+defGlobal :: Var -> [Var] -> [Forall] -> Type -> CheckM a -> CheckM a
 defGlobal x tgs ps tp = local $ modifyEnv ( \ g -> ctxtAddDefine g x tgs ps tp)
 
 defExtern :: Var -> Type -> CheckM a -> CheckM a
@@ -283,16 +283,18 @@ infer' (UsVar x) =
     CtLocal tp -> return (TmVarL x tp)
     CtDefine tgs tis tp -> h GlDefine tgs tis tp
     CtExtern tp -> h GlExtern [] [] tp
-    CtCtor tgs tis tp -> h GlCtor tgs tis tp
+    CtCtor tgs tis tp -> h GlCtor tgs [Forall y False | y <- tis] tp
   where
     h gv tgs tis tp =
+     let ytis = [y | Forall y r <- tis] in
       -- pick new tags
       mapM (const freshTag) tgs >>= \ tgs' ->
       -- pick new type vars
-      mapM (const freshTp) tis >>= \ tis' ->
+      mapM (const freshTp) ytis >>= \ tis' ->
+      mapM (\ (Forall y r, ytp) -> constrainIf r (Robust ytp)) (zip tis tis') >>
       -- substitute old tags/type vars for new ones
-      let tp' = subst (Map.fromList (pickyZip tgs (SubTg <$> tgs') ++
-                                     pickyZip tis (SubTp <$> tis'))) tp in
+       let tp' = subst (Map.fromList (pickyZip tgs (SubTg <$> tgs') ++
+                                      pickyZip ytis (SubTp <$> tis'))) tp in
         return (TmVarG gv x tgs' tis' [] tp')
 
 infer' (UsLam x xtp tm) =

--- a/src/TypeInf/Solve.hs
+++ b/src/TypeInf/Solve.hs
@@ -87,7 +87,7 @@ solvedWell :: Ctxt -> Subst -> [(Constraint, Loc)] -> [Var] -> Either (TypeError
 solvedWell e s cs xs =
   Map.unions <$> sequence [ h (subst s c) l | (c, l) <- cs ] >>= \ rfvs ->
   -- Mark each x as robust if it appears in rfvs (free vars in robust types)
-  Right [Forall x (x `Map.member` rfvs) | x <- xs]
+  Right [Forall x (if x `Map.member` rfvs then BoundRobust else BoundNone) | x <- xs]
   where
     -- Returns map of free variables in robust-constrained types
     h :: Constraint -> Loc -> Either (TypeError, Loc) (Map Var Type)

--- a/tests/good/forall_positive_unused_type_parameter.ppl
+++ b/tests/good/forall_positive_unused_type_parameter.ppl
@@ -1,0 +1,8 @@
+data MyBool a = MyFalse | MyTrue;
+data Maybe a = Nothing | Just a;
+-- Test that the robust constraint on double1 and double2 does not propagate to the parameter of MyBool
+define double1 = \x. (x, case x of MyFalse -> False | MyTrue -> True);
+define double2 = \x. (x, case x of Nothing -> False | Just y -> (case y of MyFalse -> False | MyTrue -> True));
+define b1 : MyBool (() -> ()) = MyTrue;
+define b2 : Maybe (MyBool (() -> ())) = Just MyTrue;
+(double1 b1, double2 b2)


### PR DESCRIPTION
Specifically, this change implements the following:
- Modifies the context to keep track of which `define` type params should be robust
- When we type-check a global `UsVar`, we already create a new type vars to solve for each type param in its definition. Now for each of those type params that is robust, we add the constraint that the new type var must be solved to a robust type too.
- To determine which type params must be robust in a definition, we collect all robust constraints introduced by its body and then mark each type var/param as robust if it is a free var in any of the robust-constrained types.

We can talk about this tomorrow if it's unclear in any way