### PR TITLE
freeVars/subst don't look at datatypes

### DIFF
--- a/src/Scope/Subst.hs
+++ b/src/Scope/Subst.hs
@@ -400,7 +400,7 @@ freeDatatypes NoTp = Set.empty
 
 {- substTags ytgs tp
 
-   Adds tags to type vars in type tp.
+   Adds tags to datatypes in type tp.
 
    - ytgs: Map from Vars (which are datatype names) to lists of Vars
      (which are tag names). -}

--- a/src/TypeInf/Solve.hs
+++ b/src/TypeInf/Solve.hs
@@ -7,7 +7,7 @@ import TypeInf.Check
 import Util.Helpers
 import Util.Graph (scc, SCC(..))
 import Struct.Lib
-import Scope.Subst (SubT(SubTm,SubTp,SubTg), Subst, compose, subst, freeVars, substTags)
+import Scope.Subst (SubT(SubTm,SubTp,SubTg), Subst, compose, subst, freeVars, freeDatatypes, substTags)
 import Scope.Free (robust)
 import Scope.Ctxt (Ctxt, emptyCtxt)
 
@@ -196,7 +196,7 @@ getDeps (UsProgs ps end) =
       (Map.insert x (Set.fromList (Map.keys (freeVars tm))) fdeps, ddeps)
     h (UsProgExtern x tp) deps = deps
     h (UsProgData y ps cs) (fdeps, ddeps) =
-      (fdeps, Map.insert y (Set.fromList (Map.keys (freeVars cs))) ddeps)
+      (fdeps, Map.insert y (Set.unions [freeDatatypes tp | Ctor _ tps <- cs, tp <- tps]) ddeps)
 
 -- Helper for splitProgsH
 splitProgsH :: UsProg -> ([(Var, Type, UsTm)], [(Var, Type)], [(Var, [Var], [Ctor])])


### PR DESCRIPTION
In anticipation of #103, I think it will be simpler to reduce the kinds of variables that `freeVars` and `subst` look at. There was already `substDatatypes` which duplicated functionality with `subst`; this adds `freeDataTypes`.
