### PR TITLE
Built-in Zero type, unify unsolved type vars with Zero

### DIFF
--- a/src/Struct/Helpers.hs
+++ b/src/Struct/Helpers.hs
@@ -161,7 +161,10 @@ mapProgsM :: Monad m => (Term -> m Term) -> Progs -> m Progs
 mapProgsM f (Progs ps end) =
   pure Progs <*> mapM (mapProgM f) ps <*> f end
 
--- Built-in datatype Bool
+-- Built-in datatypes
+
+tpZeroName = Var "_Zero"
+tpZero = TpData tpZeroName [] []
 
 tmUnit = TmProd Multiplicative []
 tpUnit = TpProd Multiplicative []
@@ -175,6 +178,7 @@ tmFalse = TmVarG GlCtor tmFalseName [] [] [] tpBool
 
 builtins :: [UsProg]
 builtins = [
+  UsProgData tpZeroName [] [],
   UsProgData tpBoolName [] [Ctor tmFalseName [], Ctor tmTrueName []]
   ]
 

--- a/tests/good/fail.ppl
+++ b/tests/good/fail.ppl
@@ -1,3 +1,3 @@
 fail
 
--- correct: [0]
+-- correct: []


### PR DESCRIPTION
This checks off one box in #47.

I think it's inconsequential except that an unannotated `fail` has no values at all, which I guess makes sense.

