### PR TITLE
Fix bug in DR when choosing local variable names

### DIFF
--- a/src/Compile/Compile.hs
+++ b/src/Compile/Compile.hs
@@ -317,7 +317,12 @@ domainSize g = tpSize where
 
 {- compileFile progs
 
-   Converts an elaborated program into an FGG (or returns an error). -}
+   Converts an elaborated program into an FGG (or returns an error).
+
+   Assumes that all local variables have unique names. If two local
+   variables had the same name `x` but two different types, this would
+   generate two FGG rules with lhs `x` that have external nodes with
+   differently-shaped weights. -}
 
 compileFile :: Progs -> Either String FGG
 compileFile ps =

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -108,7 +108,7 @@ processContents (CmdArgs ifn ofn c m e dr l o z) s =
   return s
   -- String to UsProgs
   >>= parse
-  -- Pick a unique name for each bound var, needed by infer (and anything else?)
+  -- Pick a unique name for each bound var (TODO: is this really needed?)
   >>= alphaRenameProgs ctxtAddUsProgs
   -- Add Bool, True, False
   >>= Right . progBuiltins

--- a/src/Transform/DR.hs
+++ b/src/Transform/DR.hs
@@ -78,17 +78,34 @@ collectFoldsFile = collectFile . collectFolds
 makeUnfoldDatatype :: Var -> [(FreeVars, Type)] -> Prog
 makeUnfoldDatatype y us = ProgData (refunTypeName y) [Ctor (refunCtorName y) [TpProd Additive [joinArrows (Map.elems fvs) tp | (fvs, tp) <- us]]]
 
--- Makes the _FoldY_ datatype, given results from collectFolds
---makeFoldDatatype :: Var -> [(Var, FreeVars)] -> Prog
---makeFoldDatatype y fs = ProgData (defunTypeName y) [Ctor (defunCtorName y i) (snds (Map.toList fvs)) | (i, (x, fvs)) <- enumerate fs]
+{- makeDisentangle g y us css
 
--- Makes the "unapply" function and Unfold datatype
+   When refunctionalizing datatype y, make the Folded/y datatype and fold/y function.
+
+   Let cs_i = case scr_i of ctor1 a_i1 a_i2 ... -> res_i1 | ...
+   be the i-th case expression whose scrutinee has type y. Let tp_i be
+   the type of cs_i.
+
+   Parameters:
+   - g: global names
+   - y: datatype name
+   - us: list whose i-th member is (fv_i, tp_i) where fv_i is the free variables of the branches of cs_i
+   - css: list whose i-th member is the branches of cs_i
+
+   Returns: (dat, fun) where
+   - dat: the new datatype, which looks like
+          data Folded/y = folded/y <fvtp_11 -> fvtp_12 -> ... -> tp1, ...>
+          where fvtp_ij is the type of fv_ij
+   - fun: the new function, which looks like
+          define fold/y = \ x . folded/y <\ fv_11 . \ fv_12 . ... case x of ctor1 ..., ...> -}
+                          
 makeDisentangle :: Ctxt -> Var -> [(FreeVars, Type)] -> [[Case]] -> (Prog, Prog)
 makeDisentangle g y us css =
   let ytp = TpData y [] []
       utp = TpData (refunTypeName y) [] []
       dat = makeUnfoldDatatype y us
-      x = newVar localName g
+      g' = ctxtAddArgs g (concat [Map.toList fv | (fv, _) <- us])
+      x = newVar localName g' -- argument of fun
       sub_ps ps = [(x, derefunSubst Refun y tp) | (x, tp) <- ps]
       alls = zipWith3 (\ (fvs, tp) cs i -> (fvs, tp, cs, i)) us css [0..]
       cscs = [let ps = sub_ps (Map.toList fvs)
@@ -102,7 +119,24 @@ makeDisentangle g y us css =
   in
     (dat, fun)
 
--- Makes the "apply" function and Fold datatype
+{- makeDefold g y tms
+
+   When defunctionalizing datatype y, make the Folded/y datatype and
+   unfold/y function (traditionally known as "apply").
+
+   Let f_i be the i-th expression that constructs a y. Let fv_i1, fv_i2, ... be the free variables of f_i.
+
+   Parameters:
+   - g: global names
+   - y: datatype name
+   - tms: list of all the f_i
+
+   Returns: (dat, fun), where
+   - dat: the new datatype, which looks like
+          data Folded/y = folded/y/site1 fv_11 fv_12 ... | ...
+   - fun: the new function, which looks like
+          define unfold/y = \ x . case x of folded/y/site1 fv_11 fv_12 ... -> f_i -}
+    
 makeDefold :: Ctxt  -> Var -> [Term] -> (Prog, Prog)
 makeDefold g y tms =
   let fname = applyName y
@@ -115,17 +149,24 @@ makeDefold g y tms =
       ctors = [Ctor x (snds ps) | Case x ps tm <- cases]
       tm = TmCase (TmVarL x ftp) (tname, [], []) cases (TpData y [] [])
   in
---    error (tname ++ " | " ++ show ctors ++ " | " ++ show cases)
     (ProgData tname ctors,
      ProgDefine fname ps tm (TpData y [] []))
 
 --------------------------------------------------
 
--- Replaces all case-ofs on a certain datatype with calls to
--- its "unapply" function
 type DisentangleM a = State.State [[Case]] a
 
--- See `disentangleFile`
+{- disentangleTerm rtp cases tm
+
+   When refunctionalizing rtp, replaces all case expressions whose
+   scrutinee has type rtp with calls to fold/rtp. Also collects the
+   branches of replaced case expressions.
+
+   Arguments:
+   - rtp: the datatype being refunctionalized
+   - cases: list whose i-th member is (fv_i, tp_i) where fv_i is the free variables of the branches of cs_i
+   - tm: the term to replace in -}
+
 disentangleTerm :: Var -> [(FreeVars, Type)] -> Term -> DisentangleM Term
 disentangleTerm rtp cases = h where
   h :: Term -> DisentangleM Term
@@ -141,21 +182,25 @@ disentangleTerm rtp cases = h where
   h (TmCase tm (y, _, _) cs tp)
     -- case tm of ...
     --   becomes
-    -- case tm of _unfoldY_ x' -> let <_, ..., x'', ..., _> = x' in x''
+    -- case tm of folded/y x' -> ((let <_, ..., x'', ..., _> = x' in x'') fv_i1 fv_i2 ...)
     | y == rtp =
       h tm >>= \ tm' ->
       mapCasesM (\ _ _ -> h) cs >>= \ cs' ->
       State.get >>= \ unfolds ->
       let i = length unfolds
-          -- Because there are no other free variables, this is safe
-          x' = localName
+          (cfvs, _) = cases !! i
+          x' = newVar localName cfvs
           x'' = localName
-          get_ps = \ (cfvs, ctp2) -> Map.toList cfvs
-          get_as = \ (cfvs, ctp2) -> paramsToArgs (Map.toList cfvs)
-          get_arr = \ (cfvs, ctp2) -> joinArrows (snds (get_ps (cfvs, ctp2))) ctp2
-          xtps = map get_arr cases
+          xtps = [joinArrows (snds (Map.toList cfvs)) ctp2 | (cfvs, ctp2) <- cases]
           xtp = TpProd Additive xtps
-          cs'' = [Case (refunCtorName rtp) [(x', xtp)] (let cfvstp2 = cases !! i in joinApps (TmElimAdditive (TmVarL x' xtp) (length xtps) i (x'', xtps !! i) (TmVarL x'' (xtps !! i)) (xtps !! i)) (get_as cfvstp2))]
+          
+          -- let <_, ..., x'', ..., _> = x' in x''
+          proj = TmElimAdditive (TmVarL x' xtp) (length xtps) i (x'', xtps !! i) (TmVarL x'' (xtps !! i)) (xtps !! i)
+          
+          -- folded/y x' -> proj fv_i1 fv_i2 ...
+          cs'' = [Case (refunCtorName rtp) [(x', xtp)] (joinApps proj (paramsToArgs (Map.toList cfvs)))]
+
+          -- case tm of cs''
           rtm = TmCase tm (refunTypeName rtp, [], []) cs'' tp
       in
         State.put (unfolds ++ [cs']) >>
@@ -177,8 +222,12 @@ disentangleTerm rtp cases = h where
 
 --------------------------------------------------
 
--- Replaces all constructor calls for a certain datatype with calls
--- to its "apply" function
+{- defoldTerm rtp tm
+
+   When defunctionalizing datatype rtp, replace all constructor calls
+   for rtp with calls to its unfold/y (traditionally known as "apply")
+   function. Also collect all the constructor calls. -}
+    
 type DefoldM a = State.State [Term] a
 
 defoldTerm :: Var -> Term -> DefoldM Term


### PR DESCRIPTION
If the alpha-renaming at Main.hs:112 is commented out, it now passes all tests. I'm not aware of any places other than Compile where term variables need to be renamed apart. Can we delete line 112?

Helps #119.
