### PR TITLE
External nonterminal

### DIFF
--- a/src/Compile/Compile.hs
+++ b/src/Compile/Compile.hs
@@ -104,6 +104,9 @@ term2fgg g (TmVarL x tp) =
 
 term2fgg g (TmVarG GlDefine x [] [] [] tp) =
   return [] -- If this is a def with no args, we already add its rule when it gets defined
+  
+term2fgg g (TmVarG GlExtern x [] [] as tp) =
+  return [] -- Rule will be supplied externally
 
 term2fgg g (TmVarG gv x [] [] as tp) =
   mapM (\ (a, atp) -> term2fgg g a) as >>= \ xss ->
@@ -116,8 +119,6 @@ term2fgg g (TmVarG gv x [] [] as tp) =
                             Just cs = ctxtLookupType g y
                             Just ci = findIndex (\ (Ctor x' _) -> x' == x) cs in
                           ElTerminal (FaCtor cs ci)
-                      GlExtern ->
-                        ElTerminal (FaExtern x (joinArrows (snds as) tp))
   in
     mkRule (TmVarG gv x [] [] as tp) (vy : ps ++ concat xss)
       (Edge (ps ++ [vy]) el :

--- a/src/Util/SumProduct.hs
+++ b/src/Util/SumProduct.hs
@@ -113,6 +113,5 @@ step fgg nts z =
       case Map.lookup el z of
                 Just w -> w
                 Nothing -> case Map.lookup el (factors fgg) of
-                             Just (_, Just w) -> w
-                             _ -> error (show el ++ " not found (extern not supported yet)")
-            
+                             Just (_, w) -> w
+                             Nothing -> error ("couldn't find weights for " ++ show el)


### PR DESCRIPTION
I don't remember why we changed externs to be factors in #35, but this changes it back to be a nonterminal, but now the nonterminal is not the lhs of any rule. Overall this simplifies the code, and fixes #122.
