### PR TITLE
Add size information to domains

### DIFF
--- a/src/Compile/Compile.hs
+++ b/src/Compile/Compile.hs
@@ -280,8 +280,10 @@ progs2fgg g (Progs ps tm) =
 
    Computes a list of all the possible inhabitants of a type. -}
 
-domainValues :: Ctxt -> Type -> [Value]
-domainValues g tp = Value <$> domainValues' g tp
+domainValues :: Ctxt -> Type -> (Int, [Value])
+domainValues g tp = (sz, dom) where
+  sz = domainSize g tp
+  dom = Value <$> domainValues' g tp
 
 domainValues' :: Ctxt -> Type -> [String]
 domainValues' g = tpVals where

--- a/src/Compile/RuleM.hs
+++ b/src/Compile/RuleM.hs
@@ -148,7 +148,7 @@ rulesToFGG dom start start_type rs =
           els
 
     checkWeights el nls w =
-      let shape = map (length . dom) nls in
+      let shape = map (fst . dom) nls in
       if compatible (tensorShape w) shape then
         w
       else
@@ -164,7 +164,7 @@ rulesToFGG dom start start_type rs =
 
     (fs, nts) = foldr (\ (el, nls) (fs, nts) ->
                          case el of ElTerminal fac ->
-                                      let w = checkWeights el nls (getWeights (length . dom) fac) in
+                                      let w = checkWeights el nls (getWeights (fst . dom) fac) in
                                           (Map.insertWith (checkTerm el) el (nls, w) fs, nts)
                                     ElNonterminal _ ->
                                       (fs, Map.insertWith (checkNonterm el) el nls nts))

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -29,7 +29,8 @@ data CmdArgs = CmdArgs {
   optDerefun :: [(TpName, DeRe)],
   optLin :: Bool,
   optOptimize :: Bool,
-  optSumProduct :: Bool
+  optSumProduct :: Bool,
+  optSuppressInterp :: Bool
 }
 
 optionsDefault = CmdArgs {
@@ -41,7 +42,8 @@ optionsDefault = CmdArgs {
   optDerefun = [],
   optLin = True,
   optOptimize = True,
-  optSumProduct = False
+  optSumProduct = False,
+  optSuppressInterp = False
 }
 
 options =
@@ -55,6 +57,8 @@ options =
      "Compile only to PPL code (not to FGG)",
    Option ['z'] [] (NoArg (\ opts -> return (opts {optSumProduct = True})))
      "Compute sum-product",
+   Option ['s'] [] (NoArg (\ opts -> return (opts {optSuppressInterp = True})))
+     "Suppress values in the output JSON (no effect if no JSON output)",
    Option ['o'] [] (ReqArg processOutfileArg "OUTFILE")
      "Output to OUTFILE",
    Option ['O'] [] (ReqArg processOptimArg "LEVEL")
@@ -103,7 +107,7 @@ alphaRenameProgs :: Substitutable p => (p -> Ctxt) -> p -> Either String p
 alphaRenameProgs gf a = return (alphaRename (gf a) a)
 
 processContents :: CmdArgs -> String -> Either String String
-processContents (CmdArgs ifn ofn c m e dr l o z) s =
+processContents (CmdArgs ifn ofn c m e dr l o z si) s =
   let e' = e && l
       c' = c && e'
   in
@@ -134,7 +138,7 @@ processContents (CmdArgs ifn ofn c m e dr l o z) s =
   -- Compile to FGG
   >>= if c' then
         \ps -> if z then show . sumProduct <$> compileFile ps
-                    else (showFGG :: FGG PatternedTensor -> String) <$> compileFile ps
+                    else (showFGG si :: FGG PatternedTensor -> String) <$> compileFile ps
       else
         showFile
                                        )

--- a/src/Util/SumProduct.hs
+++ b/src/Util/SumProduct.hs
@@ -45,7 +45,7 @@ tensorToAssoc fgg el = h (nonterminals fgg Map.! el) where
   h [] (Scalar w) =
       [([], w)]
   h (nl:nls) (Vector ts) =
-    let vals = (domains fgg) Map.! nl
+    let vals = snd $ (domains fgg) Map.! nl
         maps = [h nls t | t <- ts]
     in
       [(v:vs, w) | (v, m) <- zip vals maps, (vs, w) <- m]


### PR DESCRIPTION
Supports a new domain format `"compact"`. Compact domains contain only the size of domains. When the command line option `-s` is passed, the size of domains will be used directly so that there is no need to compute all domain values. This will improve the process time when some domains contain a large number of values.